### PR TITLE
Add support for nested models

### DIFF
--- a/models/iris_with_standoffs/model.sdf
+++ b/models/iris_with_standoffs/model.sdf
@@ -186,7 +186,7 @@
         <update_rate>1000.0</update_rate>
       </sensor>
     </link>
-    <joint name='iris/imu_joint' type='revolute'>
+    <joint name='imu_joint' type='revolute'>
       <child>imu_link</child>
       <parent>base_link</parent>
       <axis>
@@ -712,7 +712,7 @@
       <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
 
       <!-- Sensors -->
-      <imuName>imu_sensor</imuName>
+      <imuName>imu_link::imu_sensor</imuName>
 
       <!--
           incoming control command [0, 1]

--- a/models/zephyr_with_ardupilot/model.sdf
+++ b/models/zephyr_with_ardupilot/model.sdf
@@ -365,7 +365,7 @@
         <update_rate>1000.0</update_rate>
       </sensor>
     </link>
-    <joint name='zephyr/imu_joint' type='revolute'>
+    <joint name='imu_joint' type='revolute'>
       <child>imu_link</child>
       <parent>wing</parent>
       <axis>
@@ -552,7 +552,7 @@
       <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
 
       <!-- Sensors -->
-      <imuName>imu_sensor</imuName>
+      <imuName>imu_link::imu_sensor</imuName>
 
       <!--
           incoming control command [0, 1]
@@ -580,10 +580,10 @@
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
-        <i_max>0</i_max>
+        <i_max>-1</i_max>
         <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>0.0</cmd_min>
+        <cmd_max>5.0</cmd_max>
+        <cmd_min>-5.0</cmd_min>
       </control>
 
       <!-- 
@@ -610,10 +610,10 @@
         <p_gain>10.0</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
-        <i_max>0</i_max>
+        <i_max>-1</i_max>
         <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>-2.5</cmd_min>
+        <cmd_max>5.0</cmd_max>
+        <cmd_min>-5.0</cmd_min>
       </control>
 
       <!-- 
@@ -634,10 +634,10 @@
         <p_gain>10.0</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
-        <i_max>0</i_max>
+        <i_max>-1</i_max>
         <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>-2.5</cmd_min>
+        <cmd_max>5.0</cmd_max>
+        <cmd_min>-5.0</cmd_min>
       </control>
 
     </plugin>


### PR DESCRIPTION
## Bug Fix

Fixes #6

## Details

Fix the issue that the methods to find links, joints and sensors were not searching in nested models. This will permit more complex models containing sensors and other peripherals to be composed from a collection of simpler models.

### ArduPilot plugin

- Add a custom version of `Model::JointByName` implemented as a lambda
- Search for entities given a scoped name and then check that those found support the required components (`Joint` and `JointVelocity`)
- Rewrite the search for the IMU sensor component to use scoped names
- In the `ApplyForce` function add a check that the `JointVelocity` and `JointPosition` components are valid before dereferencing them

### Models

- Update the iris and zephyr models to use scoped names for the imu sensor (i.e. the name `imu_sensor` becomes `imu_link::imu_sensor`)

## Testing

Tested on a VMware Fusion 12 Ubuntu 20.04 VM with the most recent version of ignition edifice: 

```bash
$ ign gazebo --version
Ignition Gazebo, version 5.3.0
Copyright (C) 2018 Open Source Robotics Foundation.
Released under the Apache 2.0 License.
```

An example of a model composed from a nested model is available here: https://github.com/srmainwaring/SITL_Models/tree/ignition/wildthumper-nested
