### PR TITLE
Ensure the model base link is set to the correct model

### DIFF
--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -764,7 +764,6 @@ void ignition::gazebo::systems::ArduPilotPlugin::PreUpdate(
             {
                 // The parent of the imu is imu_link
                 ignition::gazebo::Entity parent = _ecm.ParentEntity(_imu_entity);
-                this->dataPtr->modelLink = parent;
                 if (parent != ignition::gazebo::kNullEntity)
                 {
                     // The grandparent of the imu is the quad itself, which is where this plugin is attached
@@ -774,6 +773,7 @@ void ignition::gazebo::systems::ArduPilotPlugin::PreUpdate(
                         ignition::gazebo::Model gparent_model(gparent);
                         if (gparent_model.Name(_ecm) == this->dataPtr->modelName)
                         {
+                            this->dataPtr->modelLink = parent;
                             imuTopicName = ignition::gazebo::scopedName(_imu_entity, _ecm) + "/imu";
                             igndbg << "Computed IMU topic to be: " << imuTopicName << std::endl;
                         }


### PR DESCRIPTION
This PR fixes a bug where the base model link associated with the `ArduPilotPlugin` may be incorrectly associated with the wrong model, leading to an incorrect pose being published. The issue is apparent in multi-vehicle simulations.  

The fix is to ensure that the link is set in the same `if` clause as the IMU topic.

**Before fix**

When running a multi-vehicle simulation, some vehicles will report incorrect position leading to poor EFK status and a loss of control of the vehicle in controlled modes.

**After fix**

All vehicles will report the correct position and expected EKF status. Tested with a 3-Iris quadcopter configuration.

![multi-vehicle-test_small](https://user-images.githubusercontent.com/24916364/150016148-e337e22a-2b54-4dec-a4d8-26e3fdd77c9f.png)

 
