### PR TITLE
Sync with upstream bumps in ignition-garden

### DIFF
--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -17,7 +17,6 @@
 #include "ArduPilotPlugin.hh"
 #include "Socket.h"
 
-#include <ignition/common/Time.hh>
 #include <ignition/common/SignalHandler.hh>
 #include <ignition/gazebo/components/AngularVelocity.hh>
 #include <ignition/gazebo/components/Imu.hh>


### PR DESCRIPTION
This PR syncs the plugin ignition-garden branch with upstream changes.


**Details**

The `ignition::common::Time` class has been deprecated in favour of `std::chrono` (https://github.com/ignitionrobotics/ign-rendering/pull/525)
