### PR TITLE
Add COMMAND control type

### DIFF
--- a/include/ArduPilotPlugin.hh
+++ b/include/ArduPilotPlugin.hh
@@ -45,7 +45,8 @@ namespace systems
   ///    channel            attribute, ardupilot control channel
   ///    multiplier         command multiplier
   ///    <!-- output to Gazebo -->
-  ///    type               type of control, VELOCITY, POSITION or EFFORT
+  ///    type               type of control, VELOCITY, POSITION, EFFORT or RELAY
+  ///    topic              if type == RELAY, publish commands to topic instead
   ///    <p_gain>           velocity pid p gain
   ///    <i_gain>           velocity pid i gain
   ///    <d_gain>           velocity pid d gain

--- a/include/ArduPilotPlugin.hh
+++ b/include/ArduPilotPlugin.hh
@@ -42,11 +42,14 @@ namespace systems
   /// The plugin requires the following parameters:
   /// <control>             control description block
   ///    <!-- inputs from Ardupilot -->
-  ///    channel            attribute, ardupilot control channel
-  ///    multiplier         command multiplier
+  ///    "channel"          attribute, ardupilot control channel
+  ///    <multiplier>       command multiplier
+  ///    <offset>           command offset
+  ///    <servo_max>        upper limit for PWM input
+  ///    <servo_min>        lower limit for PWM input
   ///    <!-- output to Gazebo -->
-  ///    type               type of control, VELOCITY, POSITION, EFFORT or RELAY
-  ///    topic              if type == RELAY, publish commands to topic instead
+  ///    <type>             type of control, VELOCITY, POSITION, EFFORT or COMMAND
+  ///    <useForce>         1 if joint forces are applied, 0 to set joint directly
   ///    <p_gain>           velocity pid p gain
   ///    <i_gain>           velocity pid i gain
   ///    <d_gain>           velocity pid d gain
@@ -55,9 +58,11 @@ namespace systems
   ///    <cmd_max>          velocity pid max command torque
   ///    <cmd_min>          velocity pid min command torque
   ///    <jointName>        motor joint, torque applied here
+  ///    <cmd_topic>        topic to publish commands that are processed by other plugins 
+  ///
   ///    <turningDirection> rotor turning direction, 'cw' or 'ccw'
-  ///    frequencyCutoff    filter incoming joint state
-  ///    samplingRate       sampling rate for filtering incoming joint state
+  ///    <frequencyCutoff>  filter incoming joint state
+  ///    <samplingRate>     sampling rate for filtering incoming joint state
   ///    <rotorVelocitySlowdownSim> for rotor aliasing problem, experimental
   /// <imuName>     scoped name for the imu sensor
   /// <connectionTimeoutMaxCount> timeout before giving up on


### PR DESCRIPTION
This PR authored by @[clydemcqueen](https://github.com/clydemcqueen)  adds a new control type `COMMAND` that forwards a command value calculated from the SITL PWM inputs to an ignition transport topic. The published command is expected to be processed by another plugin that will apply the command to the joint / joints for which it is responsible. An immediate application is to supply commands to the `ignition-gazebo` thruster system plugin for use with an ROV controlled by ArduSub. 

## Details

Example: to use the new control type on channel 0:

```xml
<control channel="0">
  <jointName>thruster1_joint</jointName>
  <servo_min>1100</servo_min>
  <servo_max>1900</servo_max>
  <type>COMMAND</type>
  <cmd_topic>/model/bluerov2/joint/thruster1_joint/cmd_thrust</cmd_topic>
  <offset>-0.5</offset>
  <multiplier>100</multiplier>
</control>
```

Here the command is being forwarded to the topic `/model/bluerov2/joint/thruster1_joint/cmd_thrust` that will be processed by the thruster plugin.

### Testing

Example usage with ArduSub and a prototype of the BlueROV2

<!-- https://user-images.githubusercontent.com/24916364/160637991-94a839c4-5673-40da-9511-fba2d674047c.mov -->

https://user-images.githubusercontent.com/24916364/160691895-d58599f6-2ce6-4809-841d-7a7c1da485fb.mov


