### PR TITLE
Add workflow for static checks

### DIFF
--- a/.github/workflows/ccpcheck.yml
+++ b/.github/workflows/ccpcheck.yml
@@ -1,0 +1,21 @@
+# GitHub Action to run cppcheck
+# 
+name: cppcheck
+
+on: [push, pull_request]
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-20.04
+    name: cppcheck
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install cppcheck
+      - name: Run cppcheck
+        run: |
+          cppcheck --std=c++17 ./include/*.hh
+          cppcheck --std=c++17 ./src/*.cc

--- a/.github/workflows/ccplint.yml
+++ b/.github/workflows/ccplint.yml
@@ -1,0 +1,28 @@
+# GitHub Action to run cpplint
+# 
+# The cpplint configuration file is:
+# 
+#   ./CPPLINT.cfg
+#
+name: ccplint
+
+on: [push, pull_request]
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-20.04
+    name: cpplint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install cpplint
+        run: |
+          pip install cpplint
+      - name: Run cpplint
+        run: |
+          cpplint ./include/*.hh
+          cpplint ./src/*.cc

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,56 @@
+# filters
+#
+# 1. [-whitespace/braces]
+#   { should almost always be at the end of the previous line
+#
+#   Allow:
+#     bool SocketAPM::pollout(uint32_t timeout_ms)
+#     {
+# 
+#   Instead of:
+#     bool SocketAPM::pollout(uint32_t timeout_ms) {
+# 
+# 2. [-runtime/references]
+#   Is this a non-const reference? If so, make const or use a pointer
+# 
+#   Allow:
+#     void last_recv_address(const char *&ip_addr, uint16_t &port);
+# 
+#   Instead of:
+#     void last_recv_address(const char *&ip_addr, uint16_t *port);
+# 
+# 3. [-whitespace/indent]
+#     private: should be indented +1 space 
+# 
+# 4. [-whitespace/blank_line]
+#     Do not leave a blank line after "private:"  
+# 
+#   3 and 4 are to allow Gazebo Sim class formatting where each
+#   function / method must have an access specifier.
+# 
+# 
+# 5. [-whitespace/newline]
+#     An else should appear on the same line as the preceding }
+# 
+#   Allow:
+#     }
+#     else if (time > this->dataPtr->lastUpdateTime)
+#     {
+# 
+#   Instead of:
+#     } else if (time > this->dataPtr->lastUpdateTime) {
+#
+# 6. [-build/include_subdir]
+#     Include the directory when naming header files  
+# 
+#   This prevent an error when including the plugin headers as:
+#     #include "GimbalSmall2dPlugin.hh"
+# 
+# 7. [-build/c++11], [+build/c++14]
+#
+#   This is to allow headers not approved for C++11 such as <chrono> etc. 
+# 
+set noparent
+filter=-whitespace/braces,-runtime/references,-whitespace/indent,-whitespace/blank_line,-whitespace/newline,-build/include_subdir,-build/c++11,+build/c++14
+linelength=80
+root=include

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ArduPilot Gazebo Plugin
 
-[![ubuntu-build](https://github.com/srmainwaring/ardupilot_gazebo-1/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/srmainwaring/ardupilot_gazebo-1/actions/workflows/ubuntu-build.yml)
+[![ubuntu-build](https://github.com/ArduPilot/ardupilot_gazebo/actions/workflows/ubuntu-build.yml/badge.svg)](https://github.com/ArduPilot/ardupilot_gazebo/actions/workflows/ubuntu-build.yml)
+[![ccplint](https://github.com/ArduPilot/ardupilot_gazebo/actions/workflows/ccplint.yml/badge.svg)](https://github.com/ArduPilot/ardupilot_gazebo/actions/workflows/ccplint.yml)
+[![cppcheck](https://github.com/ArduPilot/ardupilot_gazebo/actions/workflows/ccpcheck.yml/badge.svg)](https://github.com/ArduPilot/ardupilot_gazebo/actions/workflows/ccpcheck.yml)
 
 This is the official ArduPilot plugin for [Gazebo Sim](https://gazebosim.org/home).
 It replaces the previous

--- a/include/ArduCopterIRLockPlugin.hh
+++ b/include/ArduCopterIRLockPlugin.hh
@@ -15,8 +15,8 @@
  *
 */
 
-#ifndef _GAZEBO_ARDUCOPTERIRLOCK_PLUGIN_HH_
-#define _GAZEBO_ARDUCOPTERIRLOCK_PLUGIN_HH_
+#ifndef ARDUCOPTERIRLOCKPLUGIN_HH_
+#define ARDUCOPTERIRLOCKPLUGIN_HH_
 
 #include <string>
 #include <memory>
@@ -26,41 +26,43 @@
 
 namespace gazebo
 {
-  // Forward declare private class.
-  class ArduCopterIRLockPluginPrivate;
+// Forward declare private class.
+class ArduCopterIRLockPluginPrivate;
 
-  /// \brief A camera sensor plugin for fiducial detection
-  class GAZEBO_VISIBLE ArduCopterIRLockPlugin : public SensorPlugin
-  {
-    /// \brief Constructor
-    public: ArduCopterIRLockPlugin();
+/// \brief A camera sensor plugin for fiducial detection
+class GAZEBO_VISIBLE ArduCopterIRLockPlugin : public SensorPlugin
+{
+  /// \brief Constructor
+  public: ArduCopterIRLockPlugin();
 
-    /// \brief Destructor
-    public: virtual ~ArduCopterIRLockPlugin();
+  /// \brief Destructor
+  public: virtual ~ArduCopterIRLockPlugin();
 
-    // Documentation Inherited.
-    public: void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
+  // Documentation Inherited.
+  public: void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
 
-    /// \brief Callback when a new camera frame is available
-    /// \param[in] _image image data
-    /// \param[in] _width image width
-    /// \param[in] _height image height
-    /// \param[in] _depth image depth
-    /// \param[in] _format image format
-    public: virtual void OnNewFrame(const unsigned char *_image,
-        unsigned int _width, unsigned int _height, unsigned int _depth,
-        const std::string &_format);
+  /// \brief Callback when a new camera frame is available
+  /// \param[in] _image image data
+  /// \param[in] _width image width
+  /// \param[in] _height image height
+  /// \param[in] _depth image depth
+  /// \param[in] _format image format
+  public: virtual void OnNewFrame(const unsigned char *_image,
+      unsigned int _width, unsigned int _height, unsigned int _depth,
+      const std::string &_format);
 
-    /// \brief Publish the result
-    /// \param[in] _name Name of fiducial
-    /// \param[in] _x x position in image
-    /// \param[in] _y y position in image
-    public: virtual void Publish(const std::string &_fiducial, unsigned int _x,
-        unsigned int _y);
+  /// \brief Publish the result
+  /// \param[in] _name Name of fiducial
+  /// \param[in] _x x position in image
+  /// \param[in] _y y position in image
+  public: virtual void Publish(const std::string &_fiducial, unsigned int _x,
+      unsigned int _y);
 
-    /// \internal
-    /// \brief Pointer to private data.
-    private: std::unique_ptr<ArduCopterIRLockPluginPrivate> dataPtr;
-  };
-}
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<ArduCopterIRLockPluginPrivate> dataPtr;
+};
+
+}  // namespace gazebo
+
+#endif  // ARDUCOPTERIRLOCKPLUGIN_HH_

--- a/include/ArduPilotPlugin.hh
+++ b/include/ArduPilotPlugin.hh
@@ -14,147 +14,154 @@
  * limitations under the License.
  *
 */
-#ifndef GAZEBO_PLUGINS_ARDUPILOTPLUGIN_HH_
-#define GAZEBO_PLUGINS_ARDUPILOTPLUGIN_HH_
+#ifndef ARDUPILOTPLUGIN_HH_
+#define ARDUPILOTPLUGIN_HH_
+
+#include <memory>
 
 #include <gz/sim/System.hh>
 #include <sdf/sdf.hh>
 
-namespace gz {
-namespace sim {
+namespace gz
+{
+namespace sim
+{
 namespace systems
 {
-  // The servo packet received from ArduPilot SITL. Defined in SIM_JSON.h.
-  struct servo_packet {
-      uint16_t magic;         // 18458 expected magic value
-      uint16_t frame_rate;
-      uint32_t frame_count;
-      uint16_t pwm[16];
-  };
+// The servo packet received from ArduPilot SITL. Defined in SIM_JSON.h.
+struct servo_packet {
+    uint16_t magic;         // 18458 expected magic value
+    uint16_t frame_rate;
+    uint32_t frame_count;
+    uint16_t pwm[16];
+};
 
-  // Forward declare private data class
-  class ArduPilotSocketPrivate;
-  class ArduPilotPluginPrivate;
+// Forward declare private data class
+class ArduPilotSocketPrivate;
+class ArduPilotPluginPrivate;
 
-  /// \brief Interface ArduPilot from ardupilot stack
-  /// modeled after SITL/SIM_*
-  ///
-  /// The plugin requires the following parameters:
-  /// <control>             control description block
-  ///    <!-- inputs from Ardupilot -->
-  ///    "channel"          attribute, ardupilot control channel
-  ///    <multiplier>       command multiplier
-  ///    <offset>           command offset
-  ///    <servo_max>        upper limit for PWM input
-  ///    <servo_min>        lower limit for PWM input
-  ///    <!-- output to Gazebo -->
-  ///    <type>             type of control, VELOCITY, POSITION, EFFORT or COMMAND
-  ///    <useForce>         1 if joint forces are applied, 0 to set joint directly
-  ///    <p_gain>           velocity pid p gain
-  ///    <i_gain>           velocity pid i gain
-  ///    <d_gain>           velocity pid d gain
-  ///    <i_max>            velocity pid max integral correction
-  ///    <i_min>            velocity pid min integral correction
-  ///    <cmd_max>          velocity pid max command torque
-  ///    <cmd_min>          velocity pid min command torque
-  ///    <jointName>        motor joint, torque applied here
-  ///    <cmd_topic>        topic to publish commands that are processed by other plugins
-  ///
-  ///    <turningDirection> rotor turning direction, 'cw' or 'ccw'
-  ///    <frequencyCutoff>  filter incoming joint state
-  ///    <samplingRate>     sampling rate for filtering incoming joint state
-  ///    <rotorVelocitySlowdownSim> for rotor aliasing problem, experimental
-  /// <imuName>     scoped name for the imu sensor
-  /// <connectionTimeoutMaxCount> timeout before giving up on
-  ///                             controller synchronization
-  class GZ_SIM_VISIBLE ArduPilotPlugin:
-    public gz::sim::System,
-    public gz::sim::ISystemConfigure,
-    public gz::sim::ISystemPostUpdate,
-    public gz::sim::ISystemPreUpdate,
-    public gz::sim::ISystemReset
+/// \brief Interface ArduPilot from ardupilot stack
+/// modeled after SITL/SIM_*
+///
+/// The plugin requires the following parameters:
+/// <control>             control description block
+///    <!-- inputs from Ardupilot -->
+///    "channel"          attribute, ardupilot control channel
+///    <multiplier>       command multiplier
+///    <offset>           command offset
+///    <servo_max>        upper limit for PWM input
+///    <servo_min>        lower limit for PWM input
+///    <!-- output to Gazebo -->
+///    <type>             type of control, VELOCITY, POSITION, EFFORT or COMMAND
+///    <useForce>         1 if joint forces are applied, 0 to set joint directly
+///    <p_gain>           velocity pid p gain
+///    <i_gain>           velocity pid i gain
+///    <d_gain>           velocity pid d gain
+///    <i_max>            velocity pid max integral correction
+///    <i_min>            velocity pid min integral correction
+///    <cmd_max>          velocity pid max command torque
+///    <cmd_min>          velocity pid min command torque
+///    <jointName>        motor joint, torque applied here
+///    <cmd_topic>        topic to publish commands that are processed
+///                       by other plugins
+///
+///    <turningDirection> rotor turning direction, 'cw' or 'ccw'
+///    <frequencyCutoff>  filter incoming joint state
+///    <samplingRate>     sampling rate for filtering incoming joint state
+///    <rotorVelocitySlowdownSim> for rotor aliasing problem, experimental
+/// <imuName>     scoped name for the imu sensor
+/// <connectionTimeoutMaxCount> timeout before giving up on
+///                             controller synchronization
+class GZ_SIM_VISIBLE ArduPilotPlugin:
+  public gz::sim::System,
+  public gz::sim::ISystemConfigure,
+  public gz::sim::ISystemPostUpdate,
+  public gz::sim::ISystemPreUpdate,
+  public gz::sim::ISystemReset
 {
-    /// \brief Constructor.
-    public: ArduPilotPlugin();
+  /// \brief Constructor.
+  public: ArduPilotPlugin();
 
-    /// \brief Destructor.
-    public: ~ArduPilotPlugin();
+  /// \brief Destructor.
+  public: ~ArduPilotPlugin();
 
-    public: void Reset(const UpdateInfo &_info,
-                       EntityComponentManager &_ecm) final;
+  public: void Reset(const UpdateInfo &_info,
+                      EntityComponentManager &_ecm) final;
 
-    /// \brief Load configuration from SDF on startup.
-    public: void Configure(const gz::sim::Entity &_entity,
-                          const std::shared_ptr<const sdf::Element> &_sdf,
-                          gz::sim::EntityComponentManager &_ecm,
-                          gz::sim::EventManager &_eventMgr) final;
+  /// \brief Load configuration from SDF on startup.
+  public: void Configure(const gz::sim::Entity &_entity,
+                        const std::shared_ptr<const sdf::Element> &_sdf,
+                        gz::sim::EntityComponentManager &_ecm,
+                        gz::sim::EventManager &_eventMgr) final;
 
-    /// \brief Do the part of one update loop that involves making changes to simulation.
-    public: void PreUpdate(const gz::sim::UpdateInfo &_info,
-                           gz::sim::EntityComponentManager &_ecm) final;
+  /// \brief Do the part of one update loop that involves making
+  ///        changes to simulation.
+  public: void PreUpdate(const gz::sim::UpdateInfo &_info,
+                          gz::sim::EntityComponentManager &_ecm) final;
 
-    /// \brief Do the part of one update loop that involves reading results from simulation.
-    public: void PostUpdate(const gz::sim::UpdateInfo &_info,
-                            const gz::sim::EntityComponentManager &_ecm) final;
+  /// \brief Do the part of one update loop that involves
+  ///        reading results from simulation.
+  public: void PostUpdate(const gz::sim::UpdateInfo &_info,
+                          const gz::sim::EntityComponentManager &_ecm) final;
 
-    /// \brief Load control channels
-    private: void LoadControlChannels(
-        sdf::ElementPtr _sdf,
-        gz::sim::EntityComponentManager &_ecm);
+  /// \brief Load control channels
+  private: void LoadControlChannels(
+      sdf::ElementPtr _sdf,
+      gz::sim::EntityComponentManager &_ecm);
 
-    /// \brief Load IMU sensors
-    private: void LoadImuSensors(
-        sdf::ElementPtr _sdf,
-        gz::sim::EntityComponentManager &_ecm);
+  /// \brief Load IMU sensors
+  private: void LoadImuSensors(
+      sdf::ElementPtr _sdf,
+      gz::sim::EntityComponentManager &_ecm);
 
-    /// \brief Load GPS sensors
-    private: void LoadGpsSensors(
-        sdf::ElementPtr _sdf,
-        gz::sim::EntityComponentManager &_ecm);
+  /// \brief Load GPS sensors
+  private: void LoadGpsSensors(
+      sdf::ElementPtr _sdf,
+      gz::sim::EntityComponentManager &_ecm);
 
-    /// \brief Load Range sensors
-    private: void LoadRangeSensors(
-        sdf::ElementPtr _sdf,
-        gz::sim::EntityComponentManager &_ecm);
+  /// \brief Load Range sensors
+  private: void LoadRangeSensors(
+      sdf::ElementPtr _sdf,
+      gz::sim::EntityComponentManager &_ecm);
 
-    /// \brief Update the control surfaces controllers.
-    /// \param[in] _info Update information provided by the server.
-    private: void OnUpdate();
+  /// \brief Update the control surfaces controllers.
+  /// \param[in] _info Update information provided by the server.
+  private: void OnUpdate();
 
-    /// \brief Update PID Joint controllers.
-    /// \param[in] _dt time step size since last update.
-    private: void ApplyMotorForces(
-        const double _dt,
-        gz::sim::EntityComponentManager &_ecm);
+  /// \brief Update PID Joint controllers.
+  /// \param[in] _dt time step size since last update.
+  private: void ApplyMotorForces(
+      const double _dt,
+      gz::sim::EntityComponentManager &_ecm);
 
-    /// \brief Reset PID Joint controllers.
-    private: void ResetPIDs();
+  /// \brief Reset PID Joint controllers.
+  private: void ResetPIDs();
 
-    /// \brief Receive a servo packet from ArduPilot
-    ///
-    /// Returns true if a servo packet was received, otherwise false.
-    private: bool ReceiveServoPacket();
+  /// \brief Receive a servo packet from ArduPilot
+  ///
+  /// Returns true if a servo packet was received, otherwise false.
+  private: bool ReceiveServoPacket();
 
-    /// \brief Update the motor commands given servo PWM values
-    private: void UpdateMotorCommands(const servo_packet &_pkt);
+  /// \brief Update the motor commands given servo PWM values
+  private: void UpdateMotorCommands(const servo_packet &_pkt);
 
-    /// \brief Create the state JSON
-    private: void CreateStateJSON(
-        double _simTime,
-        const gz::sim::EntityComponentManager &_ecm) const;
+  /// \brief Create the state JSON
+  private: void CreateStateJSON(
+      double _simTime,
+      const gz::sim::EntityComponentManager &_ecm) const;
 
-    /// \brief Send state to ArduPilot
-    private: void SendState() const;
+  /// \brief Send state to ArduPilot
+  private: void SendState() const;
 
-    /// \brief Initialise flight dynamics model socket
-    private: bool InitSockets(sdf::ElementPtr _sdf) const;
+  /// \brief Initialise flight dynamics model socket
+  private: bool InitSockets(sdf::ElementPtr _sdf) const;
 
-    /// \brief Private data pointer.
-    private: std::unique_ptr<ArduPilotPluginPrivate> dataPtr;
-  };
+  /// \brief Private data pointer.
+  private: std::unique_ptr<ArduPilotPluginPrivate> dataPtr;
+};
 
-} // namespace systems
-} // namespace gazebo
-} // namespace gz
+}  // namespace systems
+}  // namespace sim
+}  // namespace gz
 
-#endif // GAZEBO_PLUGINS_ARDUPILOTPLUGIN_HH_
+#endif  // ARDUPILOTPLUGIN_HH_

--- a/include/GimbalSmall2dPlugin.hh
+++ b/include/GimbalSmall2dPlugin.hh
@@ -14,35 +14,39 @@
  * limitations under the License.
  *
 */
-#ifndef GAZEBO_PLUGINS_GIMBALSMALL2DPLUGIN_HH_
-#define GAZEBO_PLUGINS_GIMBALSMALL2DPLUGIN_HH_
+#ifndef GIMBALSMALL2DPLUGIN_HH_
+#define GIMBALSMALL2DPLUGIN_HH_
 
-#include "gazebo/common/Plugin.hh"
-#include "gazebo/physics/physics.hh"
-#include "gazebo/util/system.hh"
+#include <memory>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/util/system.hh>
 
 namespace gazebo
 {
-  // Forward declare private data class
-  class GimbalSmall2dPluginPrivate;
+// Forward declare private data class
+class GimbalSmall2dPluginPrivate;
 
-  /// \brief A plugin for controlling the angle of a gimbal joint
-  class GAZEBO_VISIBLE GimbalSmall2dPlugin : public ModelPlugin
-  {
-    /// \brief Constructor
-    public: GimbalSmall2dPlugin();
+/// \brief A plugin for controlling the angle of a gimbal joint
+class GAZEBO_VISIBLE GimbalSmall2dPlugin : public ModelPlugin
+{
+  /// \brief Constructor
+  public: GimbalSmall2dPlugin();
 
-    // Documentation Inherited.
-    public: virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  // Documentation Inherited.
+  public: virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
 
-    // Documentation Inherited.
-    public: virtual void Init();
+  // Documentation Inherited.
+  public: virtual void Init();
 
-    /// \brief Callback on world update
-    private: void OnUpdate();
+  /// \brief Callback on world update
+  private: void OnUpdate();
 
-    /// \brief Private data pointer
-    private: std::unique_ptr<GimbalSmall2dPluginPrivate> dataPtr;
-  };
-}
-#endif
+  /// \brief Private data pointer
+  private: std::unique_ptr<GimbalSmall2dPluginPrivate> dataPtr;
+};
+
+}  // namespace gazebo
+
+#endif  // GIMBALSMALL2DPLUGIN_HH_

--- a/include/SelectionBuffer.hh
+++ b/include/SelectionBuffer.hh
@@ -14,65 +14,68 @@
  * limitations under the License.
  *
 */
-#ifndef _GAZEBO_RENDERING_SELECTION_BUFFER_SELECTIONBUFFER_HH_
-#define _GAZEBO_RENDERING_SELECTION_BUFFER_SELECTIONBUFFER_HH_
+#ifndef SELECTIONBUFFER_HH_
+#define SELECTIONBUFFER_HH_
 
 #include <memory>
 #include <string>
-#include "gazebo/util/system.hh"
+
+#include <gazebo/util/system.hh>
 
 namespace Ogre
 {
-  class Entity;
-  class RenderTarget;
-  class SceneManager;
-}
+class Entity;
+class RenderTarget;
+class SceneManager;
+}  // Ogre
 
 namespace gazebo
 {
-  namespace rendering
-  {
-    struct SelectionBufferPrivate;
+namespace rendering
+{
+struct SelectionBufferPrivate;
 
-    class GZ_RENDERING_VISIBLE SelectionBuffer
-    {
-      /// \brief Constructor
-      /// \param[in] _camera Name of the camera to generate a selection
-      /// buffer for.
-      /// \param[in] _mgr Pointer to the scene manager.
-      /// \param[in] _renderTarget Pointer to the render target.
-      public: SelectionBuffer(const std::string &_cameraName,
-                  Ogre::SceneManager *_mgr, Ogre::RenderTarget *_renderTarget);
+class GZ_RENDERING_VISIBLE SelectionBuffer
+{
+  /// \brief Constructor
+  /// \param[in] _camera Name of the camera to generate a selection
+  /// buffer for.
+  /// \param[in] _mgr Pointer to the scene manager.
+  /// \param[in] _renderTarget Pointer to the render target.
+  public: SelectionBuffer(const std::string &_cameraName,
+              Ogre::SceneManager *_mgr, Ogre::RenderTarget *_renderTarget);
 
-      /// \brief Destructor
-      public: ~SelectionBuffer();
+  /// \brief Destructor
+  public: ~SelectionBuffer();
 
-      /// \brief Handle on mouse click
-      /// \param[in] _x X coordinate in pixels.
-      /// \param[in] _y Y coordinate in pixels.
-      /// \return Returns the Ogre entity at the coordinate.
-      public: Ogre::Entity *OnSelectionClick(int _x, int _y);
+  /// \brief Handle on mouse click
+  /// \param[in] _x X coordinate in pixels.
+  /// \param[in] _y Y coordinate in pixels.
+  /// \return Returns the Ogre entity at the coordinate.
+  public: Ogre::Entity *OnSelectionClick(int _x, int _y);
 
-      /// \brief Debug show overlay
-      /// \param[in] _show True to show the selection buffer in an overlay.
-      public: void ShowOverlay(bool _show);
+  /// \brief Debug show overlay
+  /// \param[in] _show True to show the selection buffer in an overlay.
+  public: void ShowOverlay(bool _show);
 
-      /// \brief Call this to update the selection buffer contents
-      public: void Update();
+  /// \brief Call this to update the selection buffer contents
+  public: void Update();
 
-      /// \brief Delete the render texture
-      private: void DeleteRTTBuffer();
+  /// \brief Delete the render texture
+  private: void DeleteRTTBuffer();
 
-      /// \brief Create the render texture
-      private: void CreateRTTBuffer();
+  /// \brief Create the render texture
+  private: void CreateRTTBuffer();
 
-      /// \brief Create the selection buffer offscreen render texture.
-      private: void CreateRTTOverlays();
+  /// \brief Create the selection buffer offscreen render texture.
+  private: void CreateRTTOverlays();
 
-      /// \internal
-      /// \brief Pointer to private data.
-      private: std::unique_ptr<SelectionBufferPrivate> dataPtr;
-    };
-  }
-}
-#endif
+  /// \internal
+  /// \brief Pointer to private data.
+  private: std::unique_ptr<SelectionBufferPrivate> dataPtr;
+};
+
+}  // namespace rendering
+}  // namespace gazebo
+
+#endif  // SELECTIONBUFFER_HH_

--- a/include/Socket.h
+++ b/include/Socket.h
@@ -1,4 +1,6 @@
 /*
+   Copyright (C) 2022 ardupilot.org
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
@@ -28,42 +30,44 @@
 
 class SocketAPM {
 public:
-    SocketAPM(bool _datagram);
-    SocketAPM(bool _datagram, int _fd);
-    ~SocketAPM();
+  explicit SocketAPM(bool _datagram);
+  SocketAPM(bool _datagram, int _fd);
+  ~SocketAPM();
 
-    bool connect(const char *address, uint16_t port);
-    bool bind(const char *address, uint16_t port);
-    bool reuseaddress();
-    bool set_blocking(bool blocking);
-    bool set_cloexec();
-    void set_broadcast(void);
+  bool connect(const char *address, uint16_t port);
+  bool bind(const char *address, uint16_t port);
+  bool reuseaddress();
+  bool set_blocking(bool blocking);
+  bool set_cloexec();
+  void set_broadcast(void);
 
-    ssize_t send(const void *pkt, size_t size);
-    ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
-    ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
+  ssize_t send(const void *pkt, size_t size);
+  ssize_t sendto(const void *buf, size_t size,
+      const char *address, uint16_t port);
+  ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
-    // return the IP address and port of the last received packet
-    void last_recv_address(const char *&ip_addr, uint16_t &port);
+  // return the IP address and port of the last received packet
+  void last_recv_address(const char *&ip_addr, uint16_t &port);
 
-    // return true if there is pending data for input
-    bool pollin(uint32_t timeout_ms);
+  // return true if there is pending data for input
+  bool pollin(uint32_t timeout_ms);
 
-    // return true if there is room for output data
-    bool pollout(uint32_t timeout_ms);
+  // return true if there is room for output data
+  bool pollout(uint32_t timeout_ms);
 
-    // start listening for new tcp connections
-    bool listen(uint16_t backlog);
+  // start listening for new tcp connections
+  bool listen(uint16_t backlog);
 
-    // accept a new connection. Only valid for TCP connections after
-    // listen has been used. A new socket is returned
-    SocketAPM *accept(uint32_t timeout_ms);
+  // accept a new connection. Only valid for TCP connections after
+  // listen has been used. A new socket is returned
+  SocketAPM *accept(uint32_t timeout_ms);
 
 private:
-    bool datagram;
-    struct sockaddr_in in_addr {};
+  bool datagram;
+  struct sockaddr_in in_addr {};
 
-    int fd = -1;
+  int fd = -1;
 
-    void make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr);
+  void make_sockaddr(const char *address, uint16_t port,
+      struct sockaddr_in &sockaddr);
 };

--- a/src/ArduCopterIRLockPlugin.cc
+++ b/src/ArduCopterIRLockPlugin.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include "ArduCopterIRLockPlugin.hh"
+
 #include <memory>
 #include <functional>
 
@@ -45,48 +47,47 @@
 #include <gazebo/rendering/Camera.hh>
 #include <gazebo/rendering/Conversions.hh>
 #include <gazebo/rendering/Scene.hh>
-#include <include/SelectionBuffer.hh>
 
-#include "include/ArduCopterIRLockPlugin.hh"
+#include <SelectionBuffer.hh>
 
-using namespace gazebo;
-GZ_REGISTER_SENSOR_PLUGIN(ArduCopterIRLockPlugin)
+GZ_REGISTER_SENSOR_PLUGIN(gazebo::ArduCopterIRLockPlugin)
 
 namespace gazebo
 {
-  class ArduCopterIRLockPluginPrivate
-  {
-    /// \brief Pointer to the parent camera sensor
-    public: sensors::CameraSensorPtr parentSensor;
+class ArduCopterIRLockPluginPrivate
+{
+  /// \brief Pointer to the parent camera sensor
+  public: sensors::CameraSensorPtr parentSensor;
 
-    /// \brief Selection buffer used for occlusion detection
-    public: std::unique_ptr<rendering::SelectionBuffer> selectionBuffer;
+  /// \brief Selection buffer used for occlusion detection
+  public: std::unique_ptr<rendering::SelectionBuffer> selectionBuffer;
 
-    /// \brief All event connections.
-    public: std::vector<event::ConnectionPtr> connections;
+  /// \brief All event connections.
+  public: std::vector<event::ConnectionPtr> connections;
 
-    /// \brief A list of fiducials tracked by this camera.
-    public: std::vector<std::string> fiducials;
+  /// \brief A list of fiducials tracked by this camera.
+  public: std::vector<std::string> fiducials;
 
-    /// \brief Irlock address
-    public: std::string irlock_addr;
+  /// \brief Irlock address
+  public: std::string irlock_addr;
 
-    /// \brief Irlock port for receiver socket
-    public: uint16_t irlock_port;
+  /// \brief Irlock port for receiver socket
+  public: uint16_t irlock_port;
 
-    public: int handle;
+  public: int handle;
 
-    public: struct irlockPacket
-            {
-              uint64_t timestamp;
-              uint16_t num_targets;
-              float pos_x;
-              float pos_y;
-              float size_x;
-              float size_y;
-            };
-  };
-}
+  public: struct irlockPacket
+          {
+            uint64_t timestamp;
+            uint16_t num_targets;
+            float pos_x;
+            float pos_y;
+            float size_x;
+            float size_y;
+          };
+};
+
+}  // namespace gazebo
 
 /////////////////////////////////////////////////
 gz::math::Vector2i GetScreenSpaceCoords(gz::math::Vector3d _pt,

--- a/src/GimbalSmall2dPlugin.cc
+++ b/src/GimbalSmall2dPlugin.cc
@@ -14,19 +14,19 @@
  * limitations under the License.
  *
 */
+#include "GimbalSmall2dPlugin.hh"
+
 #include <string>
 #include <vector>
 
-#include "gazebo/common/PID.hh"
-#include "gazebo/physics/physics.hh"
-#include "gazebo/transport/transport.hh"
-#include "GimbalSmall2dPlugin.hh"
-
-using namespace gazebo;
-using namespace std;
+#include <gazebo/common/PID.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/transport.hh>
 
 GZ_REGISTER_MODEL_PLUGIN(GimbalSmall2dPlugin)
 
+namespace gazebo
+{
 /// \brief Private data class
 class gazebo::GimbalSmall2dPluginPrivate
 {
@@ -160,3 +160,5 @@ void GimbalSmall2dPlugin::OnUpdate()
     this->dataPtr->pub->Publish(m);
   }
 }
+
+}  // namespace gazebo

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -1,4 +1,6 @@
 /*
+   Copyright (C) 2022 ardupilot.org
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
@@ -23,7 +25,7 @@
   constructor
  */
 SocketAPM::SocketAPM(bool _datagram) :
-    SocketAPM(_datagram, 
+    SocketAPM(_datagram,
               socket(AF_INET, _datagram?SOCK_DGRAM:SOCK_STREAM, 0))
 {}
 
@@ -46,7 +48,8 @@ SocketAPM::~SocketAPM()
     }
 }
 
-void SocketAPM::make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr)
+void SocketAPM::make_sockaddr(const char *address, uint16_t port,
+    struct sockaddr_in &sockaddr)
 {
     memset(&sockaddr, 0, sizeof(sockaddr));
 
@@ -129,11 +132,13 @@ ssize_t SocketAPM::send(const void *buf, size_t size)
 /*
   send some data
  */
-ssize_t SocketAPM::sendto(const void *buf, size_t size, const char *address, uint16_t port)
+ssize_t SocketAPM::sendto(const void *buf, size_t size,
+    const char *address, uint16_t port)
 {
     struct sockaddr_in sockaddr;
     make_sockaddr(address, port, sockaddr);
-    return ::sendto(fd, buf, size, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    return ::sendto(fd, buf, size, 0,
+        (struct sockaddr *)&sockaddr, sizeof(sockaddr));
 }
 
 /*
@@ -145,7 +150,8 @@ ssize_t SocketAPM::recv(void *buf, size_t size, uint32_t timeout_ms)
         return -1;
     }
     socklen_t len = sizeof(in_addr);
-    return ::recvfrom(fd, buf, size, MSG_DONTWAIT, (sockaddr *)&in_addr, &len);
+    return ::recvfrom(fd, buf, size, MSG_DONTWAIT,
+        reinterpret_cast<sockaddr *>(&in_addr), &len);
 }
 
 /*
@@ -160,7 +166,8 @@ void SocketAPM::last_recv_address(const char *&ip_addr, uint16_t &port)
 void SocketAPM::set_broadcast(void)
 {
     int one = 1;
-    setsockopt(fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
+    setsockopt(fd, SOL_SOCKET, SO_BROADCAST,
+        reinterpret_cast<char *>(&one), sizeof(one));
 }
 
 /*
@@ -209,7 +216,7 @@ bool SocketAPM::pollout(uint32_t timeout_ms)
  */
 bool SocketAPM::listen(uint16_t backlog)
 {
-    return ::listen(fd, (int)backlog) == 0;
+    return ::listen(fd, static_cast<int>(backlog)) == 0;
 }
 
 /*


### PR DESCRIPTION
This PR adds workflows for static checks using [cpplint](https://github.com/cpplint/cpplint) and [cppcheck]().

The style enforced is largely that outlined in the [Google Style Guide](https://github.com/google/styleguide) with filters to allow the style modifications described in the [Gazebo style guide](https://gazebosim.org/docs/garden/contributing#style-guides).