### PR TITLE
Add support for nested models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(ArduPilotPlugin
     SHARED
     src/ArduPilotPlugin.cc
     src/Socket.cpp
+    src/Util.cc
 )
 
 target_include_directories(ArduPilotPlugin PUBLIC

--- a/include/Util.hh
+++ b/include/Util.hh
@@ -1,0 +1,60 @@
+/*
+   Copyright (C) 2022 ardupilot.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <gz/sim/Entity.hh>
+#include <gz/sim/EntityComponentManager.hh>
+#include <gz/sim/Export.hh>
+
+namespace gz
+{
+namespace sim
+{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+
+/// \brief Helper function to get an entity given its unscoped name.
+///
+/// \param[in] _name Entity's unscoped name.
+/// \param[in] _ecm Immutable reference to ECM.
+/// \param[in] _relativeTo Entity that the unscoped name is relative to.
+/// If not provided, the unscoped name could be relative to any entity.
+/// \return All entities that match the unscoped name and relative to
+/// requirements, or an empty set otherwise.
+std::unordered_set<Entity> EntitiesFromUnscopedName(
+    const std::string &_name, const EntityComponentManager &_ecm,
+    Entity _relativeTo = kNullEntity);
+
+/// \brief Get the ID of a joint entity which is a descendent of this model.
+///
+/// A replacement for gz::sim::Model::JointByName which does not resolve
+/// joints for nested models.
+/// \param[in] _ecm Entity-component manager.
+/// \param[in] _entity Model entity.
+/// \param[in] _name Scoped joint name.
+/// \return Joint entity.
+Entity JointByName(EntityComponentManager &_ecm,
+    Entity _modelEntity,
+    const std::string &_name);
+
+}
+}  // namespace sim
+}  // namespace gz

--- a/models/iris_with_ardupilot/model.config
+++ b/models/iris_with_ardupilot/model.config
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <model>
-  <name>Iris with Standoffs and Camera LiftDrag ArduCopter Plugins</name>
+  <name>Iris with ArduCopter</name>
   <version>1.0</version>
   <sdf version="1.6">model.sdf</sdf>
 
@@ -24,9 +24,8 @@
 
   <maintainer email="hsu@osrfoundation.org">john hsu</maintainer>
 
-
   <description>
-    starting with iris_with_standoffs
+    Starting with iris_with_standoffs
     add LiftDragPlugin
     add ArduCopterPlugin
     attach gimbal_small_2d model with GimbalSmall2dPlugin

--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -1,10 +1,11 @@
 <?xml version='1.0'?>
 <sdf version="1.6">
-  <model name="iris_demo">
+  <model name="iris_with_ardupilot">
     <include>
       <uri>model://iris_with_standoffs</uri>
     </include>
 
+    <!-- TODO: migrate gimbal model to Gazebo Sim and add camera.
     <include>
       <uri>model://gimbal_small_2d</uri>
       <pose>0 -0.01 0.070 1.57 0 1.57</pose>
@@ -22,6 +23,8 @@
         <use_parent_model_frame>true</use_parent_model_frame>
       </axis>
     </joint>
+    -->
+
     <!-- visual markers for debugging
     <link name="rotor_0_blade_1_cp">
       <gravity>0</gravity>
@@ -381,7 +384,11 @@
     -->
 
     <!-- plugins -->
-    <plugin name="rotor_0_blade_1" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-joint-state-publisher-system"
+      name="gz::sim::systems::JointStatePublisher">
+    </plugin>
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -395,9 +402,10 @@
       <cp>0.084 0 0</cp>
       <forward>0 1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_0</link_name>
+      <link_name>iris_with_standoffs::rotor_0</link_name>
     </plugin>
-    <plugin name="rotor_0_blade_2" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -411,10 +419,11 @@
       <cp>-0.084 0 0</cp>
       <forward>0 -1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_0</link_name>
+      <link_name>iris_with_standoffs::rotor_0</link_name>
     </plugin>
 
-    <plugin name="rotor_1_blade_1" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -428,9 +437,10 @@
       <cp>0.084 0 0</cp>
       <forward>0 1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_1</link_name>
+      <link_name>iris_with_standoffs::rotor_1</link_name>
     </plugin>
-    <plugin name="rotor_1_blade_2" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -444,10 +454,11 @@
       <cp>-0.084 0 0</cp>
       <forward>0 -1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_1</link_name>
+      <link_name>iris_with_standoffs::rotor_1</link_name>
     </plugin>
 
-    <plugin name="rotor_2_blade_1" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -461,9 +472,10 @@
       <cp>0.084 0 0</cp>
       <forward>0 -1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_2</link_name>
+      <link_name>iris_with_standoffs::rotor_2</link_name>
     </plugin>
-    <plugin name="rotor_2_blade_2" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -477,10 +489,11 @@
       <cp>-0.084 0 0</cp>
       <forward>0 1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_2</link_name>
+      <link_name>iris_with_standoffs::rotor_2</link_name>
     </plugin>
 
-    <plugin name="rotor_3_blade_1" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -494,9 +507,10 @@
       <cp>0.084 0 0</cp>
       <forward>0 -1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_3</link_name>
+      <link_name>iris_with_standoffs::rotor_3</link_name>
     </plugin>
-    <plugin name="rotor_3_blade_2" filename="libLiftDragPlugin">
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
@@ -510,21 +524,42 @@
       <cp>-0.084 0 0</cp>
       <forward>0 1 0</forward>
       <upward>0 0 1</upward>
-      <link_name>iris::rotor_3</link_name>
+      <link_name>iris_with_standoffs::rotor_3</link_name>
     </plugin>
-    <plugin name="arducopter_plugin" filename="libArduPilotPlugin">
+
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>iris_with_standoffs::rotor_0_joint</joint_name>
+    </plugin>
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>iris_with_standoffs::rotor_1_joint</joint_name>
+    </plugin>
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>iris_with_standoffs::rotor_2_joint</joint_name>
+    </plugin>
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>iris_with_standoffs::rotor_3_joint</joint_name>
+    </plugin>
+
+    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin">
+      <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>
-      <fdm_port_out>9003</fdm_port_out>
-      <!--
-          Require by APM :
-          Only change model and gazebo from XYZ to XY-Z coordinates
+      <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
+      <lock_step>1</lock_step>
+
+      <!-- Frame conventions
+        Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates
       -->
       <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
       <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
-      <imuName>iris_demo::iris::iris/imu_link::imu_sensor</imuName>
-      <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
-      <control channel="0">
+
+      <!-- Sensors -->
+      <imuName>iris_with_standoffs::imu_link::imu_sensor</imuName>
+
       <!--
           incoming control command [0, 1]
           so offset it by 0 to get [0, 1]
@@ -532,8 +567,14 @@
           offset = 0
           multiplier = 838 max rpm / 1 = 838
         -->
-        <type>VELOCITY</type>
+      <control channel="0">
+        <jointName>iris_with_standoffs::rotor_0_joint</jointName>
+        <useForce>1</useForce>
+        <multiplier>838</multiplier>
         <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -541,27 +582,35 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
-        <jointName>iris::rotor_0_joint</jointName>
-        <multiplier>838</multiplier>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
+
       <control channel="1">
-        <type>VELOCITY</type>
-        <offset>0</offset>
-        <p_gain>0.20</p_gain>
-        <i_gain>0</i_gain>
-        <d_gain>0</d_gain>
-        <i_max>0</i_max>
-        <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>-2.5</cmd_min>
-        <jointName>iris::rotor_1_joint</jointName>
+        <jointName>iris_with_standoffs::rotor_1_joint</jointName>
+        <useForce>1</useForce>
         <multiplier>838</multiplier>
+        <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
+        <p_gain>0.20</p_gain>
+        <i_gain>0</i_gain>
+        <d_gain>0</d_gain>
+        <i_max>0</i_max>
+        <i_min>0</i_min>
+        <cmd_max>2.5</cmd_max>
+        <cmd_min>-2.5</cmd_min>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
+
       <control channel="2">
-        <type>VELOCITY</type>
+        <jointName>iris_with_standoffs::rotor_2_joint</jointName>
+        <useForce>1</useForce>
+        <multiplier>-838</multiplier>
         <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -569,13 +618,17 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
-        <jointName>iris::rotor_2_joint</jointName>
-        <multiplier>-838</multiplier>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
+
       <control channel="3">
-        <type>VELOCITY</type>
+        <jointName>iris_with_standoffs::rotor_3_joint</jointName>
+        <useForce>1</useForce>
+        <multiplier>-838</multiplier>
         <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -583,8 +636,6 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
-        <jointName>iris::rotor_3_joint</jointName>
-        <multiplier>-838</multiplier>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
     </plugin>

--- a/models/iris_with_standoffs/model.config
+++ b/models/iris_with_standoffs/model.config
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-
 <model>
   <name>Iris with Standoffs</name>
   <version>1.0</version>
@@ -23,7 +22,6 @@
   </author>
 
   <maintainer email="hsu@osrfoundation.org">john hsu</maintainer>
-
 
   <description>
     A copy of the 3DR Iris model taken from

--- a/models/iris_with_standoffs/model.sdf
+++ b/models/iris_with_standoffs/model.sdf
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
-<sdf version='1.5'>
-  <model name='iris'>
+<sdf version='1.6'>
+  <model name='iris_with_standoffs'>
     <pose>0 0 0.194923 0 0 0</pose>
     <link name='base_link'>
       <velocity_decay>
@@ -19,7 +19,7 @@
           <izz>0.017</izz>
         </inertia>
       </inertial>
-      <collision name='base_link_collision'>
+      <collision name='base_collision'>
         <pose>0 0 -0.08 0 0 0</pose>
         <geometry>
           <box>
@@ -41,7 +41,7 @@
           </friction>
         </surface>
       </collision>
-      <visual name='base_link_visual'>
+      <visual name='base_visual'>
         <geometry>
           <mesh>
             <uri>model://iris_with_standoffs/meshes/iris.dae</uri>
@@ -130,43 +130,6 @@
         </material>
       </visual>
     </link>
-    <link name='iris/ground_truth/odometry_sensorgt_link'>
-      <pose>0 0 0 0 -0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 -0 0</pose>
-        <mass>0.15</mass>
-        <inertia>
-          <ixx>0.0001</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.0002</iyy>
-          <iyz>0</iyz>
-          <izz>0.0002</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='iris/ground_truth/odometry_sensorgt_joint' type='revolute'>
-      <child>iris/ground_truth/odometry_sensorgt_link</child>
-      <parent>base_link</parent>
-      <axis>
-        <xyz>0 0 1</xyz>
-        <limit>
-          <lower>0</lower>
-          <upper>0</upper>
-          <effort>0</effort>
-          <velocity>0</velocity>
-        </limit>
-        <dynamics>
-          <damping>1.0</damping>
-        </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-        </ode>
-      </physics>
-    </joint>
     <link name='imu_link'>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
@@ -186,7 +149,7 @@
         <update_rate>1000.0</update_rate>
       </sensor>
     </link>
-    <joint name='iris/imu_joint' type='revolute'>
+    <joint name='imu_joint' type='revolute'>
       <child>imu_link</child>
       <parent>base_link</parent>
       <axis>
@@ -200,49 +163,8 @@
         <dynamics>
           <damping>1.0</damping>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-        </ode>
-      </physics>
-    </joint>
-<!--
-    <link name='iris/imugt_link'>
-      <pose>0 0 0 0 -0 0</pose>
-      <inertial>
-        <pose>0 0 0 0 -0 0</pose>
-        <mass>1e-02</mass>
-        <inertia>
-          <ixx>0.0002</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.0002</iyy>
-          <iyz>0</iyz>
-          <izz>0.0002</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name='iris/imugt_joint' type='revolute'>
-      <child>iris/imugt_link</child>
-      <parent>base_link</parent>
-      <axis>
-        <xyz>0 0 1</xyz>
-        <limit>
-          <lower>0</lower>
-          <upper>0</upper>
-          <effort>0</effort>
-          <velocity>0</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
     </joint>
--->
     <link name='rotor_0'>
       <pose>0.13 -0.22 0.023 0 -0 0</pose>
       <inertial>
@@ -535,264 +457,5 @@
         </ode>
       </physics>
     </joint>
-    <static>0</static>
-
-    <!-- plugins -->
-    <plugin filename="gz-sim-joint-state-publisher-system"
-      name="gz::sim::systems::JointStatePublisher">
-    </plugin>
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>0.084 0 0</cp>
-      <forward>0 1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_0</link_name>
-    </plugin>
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>-0.084 0 0</cp>
-      <forward>0 -1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_0</link_name>
-    </plugin>
-
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>0.084 0 0</cp>
-      <forward>0 1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_1</link_name>
-    </plugin>
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>-0.084 0 0</cp>
-      <forward>0 -1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_1</link_name>
-    </plugin>
-
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>0.084 0 0</cp>
-      <forward>0 -1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_2</link_name>
-    </plugin>
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>-0.084 0 0</cp>
-      <forward>0 1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_2</link_name>
-    </plugin>
-
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>0.084 0 0</cp>
-      <forward>0 -1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_3</link_name>
-    </plugin>
-    <plugin filename="gz-sim-lift-drag-system"
-        name="gz::sim::systems::LiftDrag">
-      <a0>0.3</a0>
-      <alpha_stall>1.4</alpha_stall>
-      <cla>4.2500</cla>
-      <cda>0.10</cda>
-      <cma>0.00</cma>
-      <cla_stall>-0.025</cla_stall>
-      <cda_stall>0.0</cda_stall>
-      <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
-      <air_density>1.2041</air_density>
-      <cp>-0.084 0 0</cp>
-      <forward>0 1 0</forward>
-      <upward>0 0 1</upward>
-      <link_name>rotor_3</link_name>
-    </plugin>
-
-    <plugin filename="gz-sim-apply-joint-force-system"
-      name="gz::sim::systems::ApplyJointForce">
-      <joint_name>rotor_0_joint</joint_name>
-    </plugin>
-    <plugin filename="gz-sim-apply-joint-force-system"
-      name="gz::sim::systems::ApplyJointForce">
-      <joint_name>rotor_1_joint</joint_name>
-    </plugin>
-    <plugin filename="gz-sim-apply-joint-force-system"
-      name="gz::sim::systems::ApplyJointForce">
-      <joint_name>rotor_2_joint</joint_name>
-    </plugin>
-    <plugin filename="gz-sim-apply-joint-force-system"
-      name="gz::sim::systems::ApplyJointForce">
-      <joint_name>rotor_3_joint</joint_name>
-    </plugin>
-
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin">
-      <!-- Port settings -->
-      <fdm_addr>127.0.0.1</fdm_addr>
-      <fdm_port_in>9002</fdm_port_in>
-      <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
-      <lock_step>1</lock_step>
-
-      <!-- Frame conventions
-        Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates
-      -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
-
-      <!-- Sensors -->
-      <imuName>imu_sensor</imuName>
-
-      <!--
-          incoming control command [0, 1]
-          so offset it by 0 to get [0, 1]
-          and divide max target by 1.
-          offset = 0
-          multiplier = 838 max rpm / 1 = 838
-        -->
-      <control channel="0">
-        <jointName>rotor_0_joint</jointName>
-        <useForce>1</useForce>
-        <multiplier>838</multiplier>
-        <offset>0</offset>
-        <servo_min>1100</servo_min>
-        <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
-        <p_gain>0.20</p_gain>
-        <i_gain>0</i_gain>
-        <d_gain>0</d_gain>
-        <i_max>0</i_max>
-        <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>-2.5</cmd_min>
-        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
-      </control>
-
-      <control channel="1">
-        <jointName>rotor_1_joint</jointName>
-        <useForce>1</useForce>
-        <multiplier>838</multiplier>
-        <offset>0</offset>
-        <servo_min>1100</servo_min>
-        <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
-        <p_gain>0.20</p_gain>
-        <i_gain>0</i_gain>
-        <d_gain>0</d_gain>
-        <i_max>0</i_max>
-        <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>-2.5</cmd_min>
-        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
-      </control>
-
-      <control channel="2">
-        <jointName>rotor_2_joint</jointName>
-        <useForce>1</useForce>
-        <multiplier>-838</multiplier>
-        <offset>0</offset>
-        <servo_min>1100</servo_min>
-        <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
-        <p_gain>0.20</p_gain>
-        <i_gain>0</i_gain>
-        <d_gain>0</d_gain>
-        <i_max>0</i_max>
-        <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>-2.5</cmd_min>
-        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
-      </control>
-
-      <control channel="3">
-        <jointName>rotor_3_joint</jointName>
-        <useForce>1</useForce>
-        <multiplier>-838</multiplier>
-        <offset>0</offset>
-        <servo_min>1100</servo_min>
-        <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
-        <p_gain>0.20</p_gain>
-        <i_gain>0</i_gain>
-        <d_gain>0</d_gain>
-        <i_max>0</i_max>
-        <i_min>0</i_min>
-        <cmd_max>2.5</cmd_max>
-        <cmd_min>-2.5</cmd_min>
-        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
-      </control>
-    </plugin>
-
   </model>
 </sdf>

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -71,9 +71,6 @@ Entity JointByName(EntityComponentManager &_ecm,
     Entity _modelEntity,
     const std::string &_name)
 {
-  // // Search relative to the top level model entity
-  // Entity id{this->dataPtr->model.Entity()};
-
   // Retrieve entities from a scoped name.
   // See for example:
   //  https://github.com/gazebosim/ign-gazebo/pull/955

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -1,0 +1,118 @@
+/*
+   Copyright (C) 2022 ardupilot.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Util.hh"
+
+#include <gz/sim/components/Joint.hh>
+#include <gz/sim/components/JointVelocity.hh>
+#include <gz/sim/components/Name.hh>
+#include <gz/sim/components/ParentEntity.hh>
+#include <gz/sim/Util.hh>
+
+namespace gz
+{
+namespace sim
+{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+
+//////////////////////////////////////////////////
+std::unordered_set<Entity> EntitiesFromUnscopedName(
+    const std::string &_name, const EntityComponentManager &_ecm,
+    Entity _relativeTo)
+{
+  // holds entities that match
+  std::vector<Entity> entities;
+
+  if (_relativeTo == kNullEntity)
+  {
+    // search everything
+    entities = _ecm.EntitiesByComponents(components::Name(_name));
+  }
+  else
+  {
+    // search all descendents
+    auto descendents = _ecm.Descendants(_relativeTo);
+    for (const auto& descendent : descendents)
+    {
+      if (_ecm.EntityHasComponentType(descendent,
+          gz::sim::components::Name::typeId))
+      {
+        auto nameComp = _ecm.Component<gz::sim::components::Name>(descendent);
+        if (nameComp->Data() == _name)
+        {
+          entities.push_back(descendent);
+        }
+      }
+    }
+
+  }
+  if (entities.empty())
+    return {};
+
+  return std::unordered_set<Entity>(entities.begin(), entities.end());
+}
+
+//////////////////////////////////////////////////
+Entity JointByName(EntityComponentManager &_ecm,
+    Entity _modelEntity,
+    const std::string &_name)
+{
+  // // Search relative to the top level model entity
+  // Entity id{this->dataPtr->model.Entity()};
+
+  // Retrieve entities from a scoped name.
+  // See for example:
+  //  https://github.com/gazebosim/ign-gazebo/pull/955
+  // which applies to the LiftDrag plugin
+  auto entities = entitiesFromScopedName(_name, _ecm, _modelEntity);
+
+  if (entities.empty())
+  {
+    gzerr << "Joint with name [" << _name << "] not found. "
+          << "The joint will not respond to ArduPilot commands\n";
+    return kNullEntity;
+  }
+  else if (entities.size() > 1)
+  {
+    gzwarn << "Multiple joint entities with name[" << _name << "] found. "
+            << "Using the first one.\n";
+  }
+
+  Entity joint = *entities.begin();
+
+  // Validate
+  if (!_ecm.EntityHasComponentType(joint,
+      components::Joint::typeId))
+  {
+    gzerr << "Entity with name[" << _name << "] is not a joint\n";
+    return kNullEntity;
+  }
+
+  // Ensure the joint has a velocity component
+  if (!_ecm.EntityHasComponentType(joint,
+      components::JointVelocity::typeId))
+  {
+    _ecm.CreateComponent(joint,
+        components::JointVelocity());
+  }
+
+  return joint;
+};
+
+}
+}  // namespace sim
+}  // namespace gz

--- a/worlds/iris_arducopter_runway.world
+++ b/worlds/iris_arducopter_runway.world
@@ -39,7 +39,7 @@
     </include>
 
     <include>
-      <uri>model://iris_with_standoffs</uri>
+      <uri>model://iris_with_ardupilot</uri>
     </include>
 
   </world>


### PR DESCRIPTION
This PR adds support for nested models. This feature was available in the original version of the plugin for Gazebo11.

## Enhancement

- Fixes #6
- Supersedes #8.

## Details

Ensure methods to find links, joints and sensors search in nested models.

This change will permit more complex models containing sensors and other peripherals to be composed from a collection of simpler models.

### ArduPilot plugin

- Add a custom version of `Model::JointByName`.
- Search for entities given a scoped name and then check that those found support the required components (`Joint` and `JointVelocity`).
- In the `ApplyForce` function add a check that the `JointVelocity` and `JointPosition` components are valid before dereferencing them.
- Rewrite the search for the IMU sensor component to use scoped names ensuring backwards compatibility.

### Models

- Update the iris models to use composition. The base model `iris_with_standoffs` defines the frame and rotor joints. The composite model `iris_with_ardupilot` adds plugins and uses scoped names to refer to the included models joints and sensors.