### PR TITLE
Anemometer: add wind sensor

### DIFF
--- a/include/ArduPilotPlugin.hh
+++ b/include/ArduPilotPlugin.hh
@@ -79,7 +79,9 @@ class ArduPilotPluginPrivate;
 ///    <frequencyCutoff>  filter incoming joint state
 ///    <samplingRate>     sampling rate for filtering incoming joint state
 ///    <rotorVelocitySlowdownSim> for rotor aliasing problem, experimental
+///
 /// <imuName>     scoped name for the imu sensor
+/// <anemometer>  scoped name for the wind sensor
 /// <connectionTimeoutMaxCount> timeout before giving up on
 ///                             controller synchronization
 /// <have_32_channels>    set true if 32 channels are enabled
@@ -133,6 +135,11 @@ class GZ_SIM_VISIBLE ArduPilotPlugin:
 
   /// \brief Load range sensors
   private: void LoadRangeSensors(
+      sdf::ElementPtr _sdf,
+      gz::sim::EntityComponentManager &_ecm);
+
+  /// \brief Load wind sensors
+  private: void LoadWindSensors(
       sdf::ElementPtr _sdf,
       gz::sim::EntityComponentManager &_ecm);
 

--- a/tests/worlds/test_anemometer.sdf
+++ b/tests/worlds/test_anemometer.sdf
@@ -1,0 +1,294 @@
+<?xml version="1.0" ?>
+<!--
+  Usage
+
+  Ensure tests/worlds is added to GZ_SIM_RESOURCE_PATH
+
+  Gazebo
+
+  gz sim -v4 -s -r test_anemometer.sdf
+
+  SITL
+
+  sim_vehicle.py -D -v Rover -f JSON -/-console -/-map
+
+  MANUAL> param set WNDVN_TYPE 11
+  MANUAL> param set WNDVN_SPEED_TYPE 11
+  MANUAL> param set WNDVN_SPEED_OFS 0
+  MANUAL> module load sail
+
+-->
+<sdf version="1.7">
+  <world name="test_anemometer">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+        name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin filename="gz-sim-sensors-system"
+        name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+      <background_color>0.8 0.8 0.8</background_color>
+    </plugin>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+        name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin filename="gz-sim-user-commands-system"
+        name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+        name="gz::sim::systems::Imu">
+    </plugin>
+    <plugin filename="asv_sim2-anemometer-system"
+      name="gz::sim::systems::Anemometer">
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+      <sky></sky>
+    </scene>
+
+    <spherical_coordinates>
+      <latitude_deg>51.56991349023042</latitude_deg>
+      <longitude_deg>-4.033693921107272</longitude_deg>
+      <elevation>10.0</elevation>
+      <heading_deg>0</heading_deg>
+      <surface_model>EARTH_WGS84</surface_model>
+    </spherical_coordinates>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.6 0.6 0.6 1</specular>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <!-- Wind directed from the north at 5 m/s -->
+    <wind>
+      <linear_velocity>0 -5 0</linear_velocity>
+    </wind>
+
+    <model name="axes">
+      <static>1</static>
+      <link name="link">
+        <visual name="r">
+          <cast_shadows>0</cast_shadows>
+          <pose>5 0 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 0.01 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <emissive>1 0 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="g">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 5 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 10 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <emissive>0 1 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="b">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 0 5.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 0.01 10</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <emissive>0 0 1 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="anemometer">
+      <pose>0 0 0.5 0 0 1.57079632</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>10</mass>
+          <inertia>
+            <ixx>1.6</ixx>
+            <ixy>0</ixy>
+            <iyy>1.6</iyy>
+            <iyz>0</iyz>
+            <izz>1.6</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.0 0.5 0.0 0.7</ambient>
+            <diffuse>0.0 0.5 0.0 0.7</diffuse>
+            <specular>0.1 0.1 0.1 0.7</specular>
+          </material>
+        </visual>
+        <visual name="direction_visual">
+          <pose>0.425 0 0.5005 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.05</radius>
+              <length>0.001</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 0 0 0.7</ambient>
+            <diffuse>1 0 0 0.7</diffuse>
+            <specular>0.1 0.1 0.1 0.7</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='imu_link'>
+        <inertial>
+          <pose>0 0 0 0 0 0</pose>
+          <mass>0.15</mass>
+          <inertia>
+            <ixx>0.00001</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00002</iyy>
+            <iyz>0</iyz>
+            <izz>0.00002</izz>
+          </inertia>
+        </inertial>
+        <sensor name="imu_sensor" type="imu">
+          <pose>0 0 0 3.141593 0 0</pose>
+          <always_on>1</always_on>
+          <update_rate>1000.0</update_rate>
+        </sensor>
+      </link>
+      <joint name='imu_joint' type='revolute'>
+        <child>imu_link</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>0</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <damping>1.0</damping>
+          </dynamics>
+        </axis>
+      </joint>
+
+      <link name='anemometer_link'>
+        <inertial>
+          <pose>0 0 0 0 0 0</pose>
+          <mass>0.15</mass>
+          <inertia>
+            <ixx>0.00001</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00002</iyy>
+            <iyz>0</iyz>
+            <izz>0.00002</izz>
+          </inertia>
+        </inertial>
+        <sensor name="anemometer" type="custom" gz:type="anemometer">
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <gz:anemometer>
+            <noise type="gaussian">
+              <mean>0.2</mean>
+              <stddev>0.1</stddev>
+            </noise>
+          </gz:anemometer>
+        </sensor>
+      </link>
+      <joint name='anemometer_joint' type='revolute'>
+        <child>anemometer_link</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+            <effort>0</effort>
+            <velocity>0</velocity>
+          </limit>
+          <dynamics>
+            <damping>1.0</damping>
+          </dynamics>
+        </axis>
+      </joint>
+
+      <plugin name="ArduPilotPlugin"
+        filename="libArduPilotPlugin">
+        <fdm_addr>127.0.0.1</fdm_addr>
+        <fdm_port_in>9002</fdm_port_in>
+        <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
+        <lock_step>1</lock_step>
+        <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
+        <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
+        <imuName>imu_link::imu_sensor</imuName>
+        <anemometer>anemometer_link::anemometer</anemometer>
+      </plugin>
+
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Add support for an anemometer sensor.

## Details

The existing SITL-JSON schema includes a `windVane` element that expects the apparent wind speed and direction.

The direction is the angle radians from the forward direction using the FRD frame convention. Angles should be in the range [-PI, PI]. The speed is measured in m/s.

```javascript
windVane {
  direction: 0.0,
  speed: 0.0 
}
```

Populating `windVane` data is enabled by including an `<anemometer>` element in the plugin definition. The element should contain the scoped name of an anemometer sensor. For example:

```xml
<plugin name="ArduPilotPlugin"
  filename="ArduPilotPlugin">
  <fdm_addr>127.0.0.1</fdm_addr>
  <fdm_port_in>9002</fdm_port_in>
  <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
  <lock_step>1</lock_step>
  <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
  <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
  <imuName>imu_link::imu_sensor</imuName>
  <anemometer>anemometer_link::anemometer</anemometer>
</plugin>
``` 

where the link is specified as:

```xml
<link name='anemometer_link'>
  <inertial>
    <pose>0 0 0 0 0 0</pose>
    <mass>0.15</mass>
    <inertia>
      <ixx>0.00001</ixx>
      <ixy>0</ixy>
      <ixz>0</ixz>
      <iyy>0.00002</iyy>
      <iyz>0</iyz>
      <izz>0.00002</izz>
    </inertia>
  </inertial>
  <sensor name="anemometer" type="custom" gz:type="anemometer">
    <always_on>1</always_on>
    <update_rate>30</update_rate>
    <gz:anemometer>
      <noise type="gaussian">
        <mean>0.2</mean>
        <stddev>0.1</stddev>
      </noise>
    </gz:anemometer>
  </sensor>
</link>
```

The anemometer is a third party [Gazebo custom sensor](https://gazebosim.org/api/sensors/7/custom_sensors.html). The only requirement for the ArduPilot plugin is that the sensor publishes a `msg::Vector3d` to the sensor topic:

```bash
/world/<world_name>/model/<model_name>/link/<link_name>/sensor/<sensor_name>/anemometer
```

The sensor system is enabled by including a system plugin associated with the `<world>` element. For example:

```xml
<plugin filename="asv_sim2-anemometer-system"
    name="gz::sim::systems::Anemometer">
</plugin>
```

loads the system from the library [`asv_sim`](https://github.com/srmainwaring/asv_sim). Other implementations of an anemometer sensor may be loaded by substituting the corresponding library name and alias.

## Testing

Ensure tests/worlds is added to GZ_SIM_RESOURCE_PATH

### Gazebo

```bash
gz sim -v4 -r test_anemometer.sdf
```

### SITL

```bash
sim_vehicle.py -D -v Rover -f JSON -/-console -/-map
```

```bash
MANUAL> param set WNDVN_TYPE 11
MANUAL> param set WNDVN_SPEED_TYPE 11
MANUAL> param set WNDVN_SPEED_OFS 0
MANUAL> module load sail
```

Figure: anemometer pointing north.

![anemometer_north](https://user-images.githubusercontent.com/24916364/226380466-4bc6e4be-1e6a-450e-9f39-0fa5545d5295.jpg)

Figure: anemometer pointing east.

![anemometer_east](https://user-images.githubusercontent.com/24916364/226380489-653659b4-7c14-4b7d-83d1-eed0e68bd735.jpg)

Figure: anemometer pointing south.

![anemometer_south](https://user-images.githubusercontent.com/24916364/226380512-55eeda21-ffc3-4437-831d-670af83daac1.jpg)

Figure: anemometer pointing west.

![anemometer_west](https://user-images.githubusercontent.com/24916364/226380539-1137fda2-4bd2-4fa2-833d-0b353088c4ad.jpg)
