### PR TITLE
Enable 32 servos

### DIFF
--- a/include/ArduPilotPlugin.hh
+++ b/include/ArduPilotPlugin.hh
@@ -28,12 +28,14 @@ namespace sim
 {
 namespace systems
 {
+/// \todo(srmainwaring) handle 16 or 32 based on magic
+
 // The servo packet received from ArduPilot SITL. Defined in SIM_JSON.h.
 struct servo_packet {
     uint16_t magic;         // 18458 expected magic value
     uint16_t frame_rate;
     uint32_t frame_count;
-    uint16_t pwm[16];
+    uint16_t pwm[32];
 };
 
 // Forward declare private data class

--- a/include/ArduPilotPlugin.hh
+++ b/include/ArduPilotPlugin.hh
@@ -17,6 +17,7 @@
 #ifndef ARDUPILOTPLUGIN_HH_
 #define ARDUPILOTPLUGIN_HH_
 
+#include <array>
 #include <memory>
 
 #include <gz/sim/System.hh>
@@ -31,8 +32,15 @@ namespace systems
 /// \todo(srmainwaring) handle 16 or 32 based on magic
 
 // The servo packet received from ArduPilot SITL. Defined in SIM_JSON.h.
-struct servo_packet {
+struct servo_packet_16 {
     uint16_t magic;         // 18458 expected magic value
+    uint16_t frame_rate;
+    uint32_t frame_count;
+    uint16_t pwm[16];
+};
+
+struct servo_packet_32 {
+    uint16_t magic;         // 29569 expected magic value
     uint16_t frame_rate;
     uint32_t frame_count;
     uint16_t pwm[32];
@@ -74,6 +82,8 @@ class ArduPilotPluginPrivate;
 /// <imuName>     scoped name for the imu sensor
 /// <connectionTimeoutMaxCount> timeout before giving up on
 ///                             controller synchronization
+/// <have_32_channels>    set true if 32 channels are enabled
+///
 class GZ_SIM_VISIBLE ArduPilotPlugin:
   public gz::sim::System,
   public gz::sim::ISystemConfigure,
@@ -145,7 +155,7 @@ class GZ_SIM_VISIBLE ArduPilotPlugin:
   private: bool ReceiveServoPacket();
 
   /// \brief Update the motor commands given servo PWM values
-  private: void UpdateMotorCommands(const servo_packet &_pkt);
+  private: void UpdateMotorCommands(const std::array<uint16_t, 32> &_pwm);
 
   /// \brief Create the state JSON
   private: void CreateStateJSON(

--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -786,6 +786,7 @@
       <fdm_port_in>9002</fdm_port_in>
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
+      <have_32_channels>0</have_32_channels>
 
       <!-- Frame conventions
         Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates

--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -61,8 +61,8 @@
 // can be defined in the <plugin>.
 #define MAX_MOTORS 255
 
-// SITL JSON interface supplies 16 servo channels
-#define MAX_SERVO_CHANNELS 16
+// SITL JSON interface supplies 32 servo channels
+#define MAX_SERVO_CHANNELS 32
 
 // Register plugin
 GZ_ADD_PLUGIN(gz::sim::systems::ArduPilotPlugin,

--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -61,9 +61,6 @@
 // can be defined in the <plugin>.
 #define MAX_MOTORS 255
 
-// SITL JSON interface supplies 32 servo channels
-#define MAX_SERVO_CHANNELS 32
-
 // Register plugin
 GZ_ADD_PLUGIN(gz::sim::systems::ArduPilotPlugin,
               gz::sim::System,
@@ -236,6 +233,9 @@ class gz::sim::systems::ArduPilotPluginPrivate
 
   /// \brief Set true to enforce lock-step simulation
   public: bool isLockStep{false};
+
+  /// \brief Set true if have 32 servo channels
+  public: bool have32Channels{false};
 
   /// \brief Have we initialized subscription to the IMU data yet?
   public: bool imuInitialized{false};
@@ -474,6 +474,9 @@ void gz::sim::systems::ArduPilotPlugin::Configure(
   // Enforce lock-step simulation (has default: false)
   this->dataPtr->isLockStep =
     sdfClone->Get("lock_step", this->dataPtr->isLockStep).first;
+
+  this->dataPtr->have32Channels =
+    sdfClone->Get("have_32_channels", false).first;
 
   // Add the signal handler
   this->dataPtr->sigHandler.AddCallback(
@@ -1281,6 +1284,47 @@ void gz::sim::systems::ArduPilotPlugin::ApplyMotorForces(
 }
 
 /////////////////////////////////////////////////
+namespace
+{
+/// \brief Get a servo packet. Templated for 16 or 32 channel packets.
+template<typename TServoPacket>
+ssize_t getServoPacket(
+  SocketAPM &_sock,
+  const char *&_fcu_address,
+  uint16_t &_fcu_port_out,
+  uint32_t _waitMs,
+  const std::string &_modelName,
+  TServoPacket &_pkt
+)
+{
+    ssize_t recvSize = _sock.recv(&_pkt, sizeof(TServoPacket), _waitMs);
+
+    _sock.last_recv_address(_fcu_address, _fcu_port_out);
+
+    // drain the socket in the case we're backed up
+    int counter = 0;
+    while (true)
+    {
+        TServoPacket last_pkt;
+        auto recvSize_last = _sock.recv(&last_pkt, sizeof(TServoPacket), 0ul);
+        if (recvSize_last == -1)
+        {
+            break;
+        }
+        counter++;
+        _pkt = last_pkt;
+        recvSize = recvSize_last;
+    }
+    if (counter > 0)
+    {
+        gzwarn << "[" << _modelName << "] "
+               << "Drained n packets: " << counter << "\n";
+    }
+    return recvSize;
+}
+}  // namespace
+
+/////////////////////////////////////////////////
 bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
 {
     // Added detection for whether ArduPilot is online or not.
@@ -1306,33 +1350,102 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
         waitMs = 1;
     }
 
-    servo_packet pkt;
-    auto recvSize = this->dataPtr->sock.recv(&pkt,
-        sizeof(servo_packet), waitMs);
-
-    this->dataPtr->sock.last_recv_address(this->dataPtr->fcu_address,
-        this->dataPtr->fcu_port_out);
-
-    // drain the socket in the case we're backed up
-    int counter = 0;
-    while (true)
+#if 0
+    // 16 / 32 channel compatibility
+    uint16_t pkt_magic{0};
+    uint16_t pkt_frame_rate{0};
+    uint16_t pkt_frame_count{0};
+    std::array<uint16_t, 32> pkt_pwm;
+    ssize_t recvSize{-1};
     {
-        servo_packet last_pkt;
-        auto recvSize_last = this->dataPtr->sock.recv(&last_pkt,
-            sizeof(servo_packet), 0ul);
-        if (recvSize_last == -1)
+      servo_packet_16 pkt;
+
+      auto getPkt = [](
+        SocketAPM &_sock,
+        const char *&_fcu_address,
+        uint16_t &_fcu_port_out,
+        uint32_t _waitMs,
+        const std::string &_modelName,
+        servo_packet_16 &_pkt
+      ) -> ssize_t {
+        ssize_t recvSize = _sock.recv(&_pkt, sizeof(servo_packet_16), _waitMs);
+
+        _sock.last_recv_address(_fcu_address, _fcu_port_out);
+
+        // drain the socket in the case we're backed up
+        int counter = 0;
+        while (true)
         {
-            break;
+            servo_packet_16 last_pkt;
+            auto recvSize_last = _sock.recv(&last_pkt,
+              sizeof(servo_packet_16), 0ul);
+            if (recvSize_last == -1)
+            {
+                break;
+            }
+            counter++;
+            _pkt = last_pkt;
+            recvSize = recvSize_last;
         }
-        counter++;
-        pkt = last_pkt;
-        recvSize = recvSize_last;
+        if (counter > 0)
+        {
+            gzwarn << "[" << _modelName << "] "
+                << "Drained n packets: " << counter << "\n";
+        }
+        return recvSize;
+      };
+
+      recvSize = getPkt(
+        this->dataPtr->sock,
+        this->dataPtr->fcu_address,
+        this->dataPtr->fcu_port_out,
+        waitMs,
+        this->dataPtr->modelName,
+        pkt
+      );
+      pkt_magic = pkt.magic;
+      pkt_frame_rate = pkt.frame_rate;
+      pkt_frame_count = pkt.frame_count;
+      std::copy(std::begin(pkt.pwm), std::end(pkt.pwm), std::begin(pkt_pwm));
     }
-    if (counter > 0)
+#else
+    // 16 / 32 channel compatibility
+    uint16_t pkt_magic{0};
+    uint16_t pkt_frame_rate{0};
+    uint16_t pkt_frame_count{0};
+    std::array<uint16_t, 32> pkt_pwm;
+    ssize_t recvSize{-1};
+    if (this->dataPtr->have32Channels)
     {
-        gzwarn << "[" << this->dataPtr->modelName << "] "
-            << "Drained n packets: " << counter << "\n";
+      servo_packet_32 pkt;
+      recvSize = getServoPacket(
+          this->dataPtr->sock,
+          this->dataPtr->fcu_address,
+          this->dataPtr->fcu_port_out,
+          waitMs,
+          this->dataPtr->modelName,
+          pkt);
+      pkt_magic = pkt.magic;
+      pkt_frame_rate = pkt.frame_rate;
+      pkt_frame_count = pkt.frame_count;
+      std::copy(std::begin(pkt.pwm), std::end(pkt.pwm), std::begin(pkt_pwm));
     }
+    else
+    {
+      servo_packet_16 pkt;
+      recvSize = getServoPacket(
+          this->dataPtr->sock,
+          this->dataPtr->fcu_address,
+          this->dataPtr->fcu_port_out,
+          waitMs,
+          this->dataPtr->modelName,
+          pkt);
+      pkt_magic = pkt.magic;
+      pkt_frame_rate = pkt.frame_rate;
+      pkt_frame_count = pkt.frame_count;
+      std::copy(std::begin(pkt.pwm), std::end(pkt.pwm), std::begin(pkt_pwm));
+    }
+#endif
 
     // didn't receive a packet, increment timeout count if online, then return
     if (recvSize == -1)
@@ -1363,28 +1476,32 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
     }
 
 #if DEBUG_JSON_IO
+    int max_servo_channels = this->dataPtr->have32Channels ? 32 : 16; 
+
     // debug: inspect sitl packet
     std::ostringstream oss;
     oss << "recv " << recvSize << " bytes from "
         << this->dataPtr->fcu_address << ":"
         << this->dataPtr->fcu_port_out << "\n";
-    // oss << "magic: " << pkt.magic << "\n";
-    // oss << "frame_rate: " << pkt.frame_rate << "\n";
-    oss << "frame_count: " << pkt.frame_count << "\n";
+    // oss << "magic: " << pkt_magic << "\n";
+    // oss << "frame_rate: " << pkt_frame_rate << "\n";
+    oss << "frame_count: " << pkt_frame_count << "\n";
     // oss << "pwm: [";
-    // for (auto i=0; i<MAX_SERVO_CHANNELS - 1; ++i) {
-    //     oss << pkt.pwm[i] << ", ";
+    // for (auto i=0; i<max_servo_channels - 1; ++i) {
+    //     oss << pkt_pwm[i] << ", ";
     // }
-    // oss << pkt.pwm[MAX_SERVO_CHANNELS - 1] << "]\n";
+    // oss << pkt_pwm[max_servo_channels - 1] << "]\n";
     gzdbg << "\n" << oss.str();
 #endif
 
     // check magic, return if invalid
-    const uint16_t magic = 18458;
-    if (magic != pkt.magic)
+    constexpr uint16_t magic_16 = 18458;
+    constexpr uint16_t magic_32 = 29569;
+    uint16_t magic = this->dataPtr->have32Channels ? magic_32 : magic_16;
+    if (magic != pkt_magic)
     {
         gzwarn << "Incorrect protocol magic "
-            << pkt.magic << " should be "
+            << pkt_magic << " should be "
             << magic << "\n";
         return false;
     }
@@ -1401,17 +1518,17 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
     }
 
     // update frame rate
-    this->dataPtr->fcu_frame_rate = pkt.frame_rate;
+    this->dataPtr->fcu_frame_rate = pkt_frame_rate;
 
     // check for controller reset
-    if (pkt.frame_count < this->dataPtr->fcu_frame_count)
+    if (pkt_frame_count < this->dataPtr->fcu_frame_count)
     {
         /// \todo(anyone) implement re-initialisation
         gzwarn << "ArduPilot controller has reset\n";
     }
 
     // check for duplicate frame
-    else if (pkt.frame_count == this->dataPtr->fcu_frame_count)
+    else if (pkt_frame_count == this->dataPtr->fcu_frame_count)
     {
         gzwarn << "Duplicate input frame\n";
 
@@ -1425,40 +1542,42 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
     }
 
     // check for skipped frames
-    else if (pkt.frame_count != this->dataPtr->fcu_frame_count + 1
+    else if (pkt_frame_count != this->dataPtr->fcu_frame_count + 1
         && this->dataPtr->arduPilotOnline)
     {
         gzwarn << "Missed "
-            << pkt.frame_count - this->dataPtr->fcu_frame_count
+            << pkt_frame_count - this->dataPtr->fcu_frame_count
             << " input frames\n";
     }
 
     // update frame count
-    this->dataPtr->fcu_frame_count = pkt.frame_count;
+    this->dataPtr->fcu_frame_count = pkt_frame_count;
 
     // reset the connection timeout so we don't accumulate
     this->dataPtr->connectionTimeoutCount = 0;
 
-    this->UpdateMotorCommands(pkt);
+    this->UpdateMotorCommands(pkt_pwm);
 
     return true;
 }
 
 /////////////////////////////////////////////////
 void gz::sim::systems::ArduPilotPlugin::UpdateMotorCommands(
-    const servo_packet &_pkt)
+    const std::array<uint16_t, 32> &_pwm)
 {
+    int max_servo_channels = this->dataPtr->have32Channels ? 32 : 16; 
+
     // compute command based on requested motorSpeed
     for (unsigned i = 0; i < this->dataPtr->controls.size(); ++i)
     {
         // enforce limit on the number of <control> elements
         if (i < MAX_MOTORS)
         {
-            if (this->dataPtr->controls[i].channel < MAX_SERVO_CHANNELS)
+            if (this->dataPtr->controls[i].channel < max_servo_channels)
             {
                 // convert pwm to raw cmd: [servo_min, servo_max] => [0, 1],
                 // default is: [1000, 2000] => [0, 1]
-                const double pwm = _pkt.pwm[this->dataPtr->controls[i].channel];
+                const double pwm = _pwm[this->dataPtr->controls[i].channel];
                 const double pwm_min = this->dataPtr->controls[i].servo_min;
                 const double pwm_max = this->dataPtr->controls[i].servo_max;
                 const double multiplier = this->dataPtr->controls[i].multiplier;
@@ -1488,7 +1607,7 @@ void gz::sim::systems::ArduPilotPlugin::UpdateMotorCommands(
                     << "control[" << i << "] channel ["
                     << this->dataPtr->controls[i].channel
                     << "] is greater than the number of servo channels ["
-                    << MAX_SERVO_CHANNELS
+                    << max_servo_channels
                     << "], control not applied.\n";
             }
         }

--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -1416,7 +1416,7 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
     }
 
 #if DEBUG_JSON_IO
-    int max_servo_channels = this->dataPtr->have32Channels ? 32 : 16; 
+    int max_servo_channels = this->dataPtr->have32Channels ? 32 : 16;
 
     // debug: inspect sitl packet
     std::ostringstream oss;
@@ -1505,7 +1505,7 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
 void gz::sim::systems::ArduPilotPlugin::UpdateMotorCommands(
     const std::array<uint16_t, 32> &_pwm)
 {
-    int max_servo_channels = this->dataPtr->have32Channels ? 32 : 16; 
+    int max_servo_channels = this->dataPtr->have32Channels ? 32 : 16;
 
     // compute command based on requested motorSpeed
     for (unsigned i = 0; i < this->dataPtr->controls.size(); ++i)

--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -1350,65 +1350,6 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
         waitMs = 1;
     }
 
-#if 0
-    // 16 / 32 channel compatibility
-    uint16_t pkt_magic{0};
-    uint16_t pkt_frame_rate{0};
-    uint16_t pkt_frame_count{0};
-    std::array<uint16_t, 32> pkt_pwm;
-    ssize_t recvSize{-1};
-    {
-      servo_packet_16 pkt;
-
-      auto getPkt = [](
-        SocketAPM &_sock,
-        const char *&_fcu_address,
-        uint16_t &_fcu_port_out,
-        uint32_t _waitMs,
-        const std::string &_modelName,
-        servo_packet_16 &_pkt
-      ) -> ssize_t {
-        ssize_t recvSize = _sock.recv(&_pkt, sizeof(servo_packet_16), _waitMs);
-
-        _sock.last_recv_address(_fcu_address, _fcu_port_out);
-
-        // drain the socket in the case we're backed up
-        int counter = 0;
-        while (true)
-        {
-            servo_packet_16 last_pkt;
-            auto recvSize_last = _sock.recv(&last_pkt,
-              sizeof(servo_packet_16), 0ul);
-            if (recvSize_last == -1)
-            {
-                break;
-            }
-            counter++;
-            _pkt = last_pkt;
-            recvSize = recvSize_last;
-        }
-        if (counter > 0)
-        {
-            gzwarn << "[" << _modelName << "] "
-                << "Drained n packets: " << counter << "\n";
-        }
-        return recvSize;
-      };
-
-      recvSize = getPkt(
-        this->dataPtr->sock,
-        this->dataPtr->fcu_address,
-        this->dataPtr->fcu_port_out,
-        waitMs,
-        this->dataPtr->modelName,
-        pkt
-      );
-      pkt_magic = pkt.magic;
-      pkt_frame_rate = pkt.frame_rate;
-      pkt_frame_count = pkt.frame_count;
-      std::copy(std::begin(pkt.pwm), std::end(pkt.pwm), std::begin(pkt_pwm));
-    }
-#else
     // 16 / 32 channel compatibility
     uint16_t pkt_magic{0};
     uint16_t pkt_frame_rate{0};
@@ -1445,7 +1386,6 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
       pkt_frame_count = pkt.frame_count;
       std::copy(std::begin(pkt.pwm), std::end(pkt.pwm), std::begin(pkt_pwm));
     }
-#endif
 
     // didn't receive a packet, increment timeout count if online, then return
     if (recvSize == -1)


### PR DESCRIPTION
Enable 32 servos when the parameter SERVO_32_ENABLE is set.

This PR is the companion to https://github.com/ArduPilot/ardupilot/pull/23239 for the ArduPilot gazebo plugin.

## Details

- Add optional boolean plugin parameter `<have_32_channels>` to enable 32 rather than 16 channels.
- Add new struct for the servo packet with 32 channels and new magic number matching SITL_JSON.
- Modify UpdateMotor commands to accept a std::array of PWMs rather than the entire servo packet.
- Update ReceiveServoPacket to receive either 16 or 32 channel servo packet depending on the plugin parameter `<have_32_channels>`.

## Testing

Testing with `iris_runway.sdf` world:

#### Gazebo

```bash
gz sim -v4 -r iris_runway.sdf
```

#### SITL

```bash
sim_vehicle.py -D -v ArduCopter -f gazebo-iris --model JSON  --console
```

#### Enable 32 servos

Enable 32 servos in MAVProxy:

![servo-32-enable-mavproxy](https://user-images.githubusercontent.com/24916364/225876658-bedef5bf-6a05-4fa7-a475-b2826a1d577b.jpg)

Magic number for 32 channel servo packet received:

![servo-32-enable-gz](https://user-images.githubusercontent.com/24916364/225876709-e8ccbbfe-1498-48bc-abb9-0399583acf95.jpg)

Update plugin parameter and restart and the connection is restored.

```xml
<plugin name="ArduPilotPlugin"
  filename="libArduPilotPlugin">
  <!-- Port settings -->
  <fdm_addr>127.0.0.1</fdm_addr>
  <fdm_port_in>9002</fdm_port_in>
  <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
  <lock_step>1</lock_step>
  <have_32_channels>1</have_32_channels>
  ...
</plugin>
```

#### Disable 32 servos

![servo-32-disable-gz](https://user-images.githubusercontent.com/24916364/225877340-18bf4d06-f0ce-4be6-ade6-5d1b3cadd060.jpg)

Magic number for 16 channel servo packet received:

![servo-32-disable-mavproxy](https://user-images.githubusercontent.com/24916364/225877355-d7568442-1fc6-4357-9519-8985fbd3ef07.jpg)

Update plugin parameter and restart and the connection is restored.

```xml
<plugin name="ArduPilotPlugin"
  filename="libArduPilotPlugin">
  <!-- Port settings -->
  <fdm_addr>127.0.0.1</fdm_addr>
  <fdm_port_in>9002</fdm_port_in>
  <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
  <lock_step>1</lock_step>
  <have_32_channels>0</have_32_channels>
  ...
</plugin>
```
