### PR TITLE
ROS: build as ament package if ROS available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,37 +1,33 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+project(ardupilot_gazebo)
 
-#============================================================================
-# Initialize the project
-#============================================================================
-project(ardupilot_sitl_gazebo)
+# --------------------------------------------------------------------------- #
+# If ament_cmake is found build as an ament package, otherwise ignore.
+# This is so the system may be built for Gazebo only, if ROS is not available.
+find_package(ament_cmake)
+if(${ament_cmake_FOUND})
+  message("Building ${PROJECT_NAME} as an `ament_cmake` project.")
+endif()
 
-#------------------------------------------------------------------------
-# Compile as C++14
-
+# --------------------------------------------------------------------------- #
+# Compile as C++14.
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-#============================================================================
-# Find gz-cmake
-#============================================================================
-find_package(gz-cmake3 3.0.0 REQUIRED)
+# --------------------------------------------------------------------------- #
+# Find gz-sim and dependencies.
+find_package(gz-cmake3 REQUIRED)
 set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 
-#============================================================================
-# Search for project-specific dependencies
-#============================================================================
-
-#--------------------------------------
-# Find gz-sim
 gz_find_package(gz-sim7 REQUIRED)
 set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
 
-#--------------------------------------
-# Find RapidJSON
+# --------------------------------------------------------------------------- #
+# Find RapidJSON.
 find_package(RapidJSON REQUIRED)
 
-#======================================
-# Build plugin
+# --------------------------------------------------------------------------- #
+# Build plugin.
 
 add_library(ArduPilotPlugin
     SHARED
@@ -39,23 +35,59 @@ add_library(ArduPilotPlugin
     src/Socket.cpp
     src/Util.cc
 )
-target_include_directories(ArduPilotPlugin PUBLIC
+target_include_directories(ArduPilotPlugin PRIVATE
   include
-	${GZ-SIM_INCLUDE_DIRS}
 )
-target_link_libraries(ArduPilotPlugin PUBLIC
-  ${GZ-SIM_LIBRARIES}
+target_link_libraries(ArduPilotPlugin PRIVATE
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
 )
 
 add_library(ParachutePlugin
   SHARED
   src/ParachutePlugin.cc
 )
-target_include_directories(ParachutePlugin PUBLIC
+target_include_directories(ParachutePlugin PRIVATE
   include
-  ${GZ-SIM_INCLUDE_DIRS}
+)
+target_link_libraries(ParachutePlugin PRIVATE
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
 )
 
-target_link_libraries(ParachutePlugin PUBLIC
-  ${GZ-SIM_LIBRARIES}
+# --------------------------------------------------------------------------- #
+# Install.
+
+install(
+  TARGETS
+  ArduPilotPlugin
+  ParachutePlugin
+  DESTINATION lib/${PROJECT_NAME}
 )
+
+install(
+  DIRECTORY
+  config/
+  DESTINATION share/${PROJECT_NAME}/config
+)
+
+install(
+  DIRECTORY
+  models/
+  DESTINATION share/${PROJECT_NAME}/models
+)
+
+install(
+  DIRECTORY
+  worlds/
+  DESTINATION share/${PROJECT_NAME}/worlds
+)
+
+# --------------------------------------------------------------------------- #
+# Register as an ament package if ament_cmake is available.
+if(${ament_cmake_FOUND})
+  ament_environment_hooks(
+    "${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+  ament_environment_hooks(
+    "${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.sh.in")
+
+  ament_package()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ardupilot_gazebo)
 # --------------------------------------------------------------------------- #
 # If ament_cmake is found build as an ament package, otherwise ignore.
 # This is so the system may be built for Gazebo only, if ROS is not available.
-find_package(ament_cmake)
+find_package(ament_cmake QUIET)
 if(${ament_cmake_FOUND})
   message("Building ${PROJECT_NAME} as an `ament_cmake` project.")
 endif()

--- a/hooks/ardupilot_gazebo.dsv.in
+++ b/hooks/ardupilot_gazebo.dsv.in
@@ -1,0 +1,4 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share;@CMAKE_INSTALL_PREFIX@/share
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/models
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/worlds
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/@PROJECT_NAME@/

--- a/hooks/ardupilot_gazebo.sh.in
+++ b/hooks/ardupilot_gazebo.sh.in
@@ -1,0 +1,3 @@
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
+ament_prepend_unique_value GZ_SIM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib/@PROJECT_NAME@"

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>rapidjson-dev</build_depend>  
+  <build_depend>libgz-cmake3-dev</build_depend>
+  <build_depend>libgz-sim7-dev</build_depend>
+
   <test_depend>ament_lint_auto</test_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ardupilot_gazebo</name>
+  <version>0.0.0</version>
+  <description>Plugins and models for vehicle simulation in Gazebo Sim with ArduPilot SITL controllers</description>
+  <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
+  <license>GPL-3.0</license>
+  <author>Rhys Mainwaring</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+


### PR DESCRIPTION
Allow `ardupilot_gazebo` to be built as a ROS 2 ament package if the ament dependencies are available, otherwise default to a standalone `cmake` only build.


## Details

- Add ROS 2 `ament` package configuration.
- Build as `ament` package if possible, otherwise revert to standard `cmake` build.
- Add install section to CMakeLists.txt
- Add environment hooks to update `GZ_SIM_RESOURCE_PATH` and `GZ_SIM_SYSTEM_PLUGIN_PATH`.
