### PR TITLE
Models: drop lib prefix from plugin filename

### DIFF
--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -780,7 +780,7 @@
     </plugin>
 
     <plugin name="ArduPilotPlugin"
-      filename="libArduPilotPlugin">
+      filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -185,7 +185,7 @@
     </plugin>
 
     <plugin name="ArduPilotPlugin"
-      filename="libArduPilotPlugin">
+      filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/models/zephyr_with_ardupilot/model.sdf
+++ b/models/zephyr_with_ardupilot/model.sdf
@@ -153,7 +153,7 @@
       <joint_name>zephyr::flap_right_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/models/zephyr_with_parachute/model.sdf
+++ b/models/zephyr_with_parachute/model.sdf
@@ -185,7 +185,7 @@
       <joint_name>zephyr::flap_right_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/tests/worlds/test_anemometer.sdf
+++ b/tests/worlds/test_anemometer.sdf
@@ -277,7 +277,7 @@
       </joint>
 
       <plugin name="ArduPilotPlugin"
-        filename="libArduPilotPlugin">
+        filename="ArduPilotPlugin">
         <fdm_addr>127.0.0.1</fdm_addr>
         <fdm_port_in>9002</fdm_port_in>
         <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>


### PR DESCRIPTION
- Use filename="ArduPilotPlugin" rather than filename="libArduPilotPlugin".

## Testing

Tested iris and zephyr models with ArduPilot [master: d3f2309](https://github.com/ArduPilot/ardupilot/commit/d3f2309eac1bf522720d27b3a22c242d32e2a6cd).