### PR TITLE
Models: update to sdf version 1.9

### DIFF
--- a/models/gimbal_small_1d/model.config
+++ b/models/gimbal_small_1d/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>Gimbal Small 1D</name>
   <version>2.0</version>
-  <sdf version="1.6">model.sdf</sdf>
+  <sdf version="1.9">model.sdf</sdf>
   <author>
     <name>anonymous</name>
     <email>anonymous</email>

--- a/models/gimbal_small_1d/model.sdf
+++ b/models/gimbal_small_1d/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version='1.6'>
+<sdf version='1.9'>
   <model name='gimbal_small_1d'>
     <pose>0 0 0.18 0 0 0</pose>
     <link name='base_link'>

--- a/models/gimbal_small_2d/model.config
+++ b/models/gimbal_small_2d/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>Gimbal Small 2D</name>
   <version>2.0</version>
-  <sdf version="1.6">model.sdf</sdf>
+  <sdf version="1.9">model.sdf</sdf>
   <author>
     <name>anonymous</name>
     <email>anonymous</email>

--- a/models/gimbal_small_2d/model.sdf
+++ b/models/gimbal_small_2d/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version='1.6'>
+<sdf version='1.9'>
   <model name='gimbal_small_2d'>
     <pose>0 0 0.18 0 0 0</pose>
     <link name='base_link'>

--- a/models/iris_with_ardupilot/model.config
+++ b/models/iris_with_ardupilot/model.config
@@ -2,8 +2,8 @@
 
 <model>
   <name>Iris with ArduPilot</name>
-  <version>1.0</version>
-  <sdf version="1.6">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
 
   <author>
     <name>Fadri Furrer</name>

--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version="1.6">
+<sdf version="1.9">
   <model name="iris_with_ardupilot">
     <include>
       <uri>model://iris_with_standoffs</uri>

--- a/models/iris_with_gimbal/model.config
+++ b/models/iris_with_gimbal/model.config
@@ -2,8 +2,8 @@
 
 <model>
   <name>Iris with Gimbal</name>
-  <version>1.0</version>
-  <sdf version="1.6">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
 
   <author>
     <name>Fadri Furrer</name>
@@ -35,11 +35,11 @@
   <depend>
     <model>
       <uri>model://gimbal_small_2d</uri>
-      <version>1.0</version>
+      <version>2.0</version>
     </model>
     <model>
       <uri>model://iris_with_standoffs</uri>
-      <version>1.0</version>
+      <version>2.0</version>
     </model>
   </depend>
 </model>

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version="1.6">
+<sdf version="1.9">
   <model name="iris_with_gimbal">
     <include>
       <uri>model://iris_with_standoffs</uri>

--- a/models/iris_with_standoffs/model.config
+++ b/models/iris_with_standoffs/model.config
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <model>
   <name>Iris with Standoffs</name>
-  <version>1.0</version>
-  <sdf version="1.6">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
 
   <author>
     <name>Fadri Furrer</name>

--- a/models/iris_with_standoffs/model.sdf
+++ b/models/iris_with_standoffs/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version='1.6'>
+<sdf version='1.9'>
   <model name='iris_with_standoffs'>
     <pose>0 0 0.194923 0 0 0</pose>
     <link name='base_link'>
@@ -230,7 +230,6 @@
         <dynamics>
           <damping>0.004</damping>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -303,7 +302,6 @@
         <dynamics>
           <damping>0.004</damping>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -376,7 +374,6 @@
         <dynamics>
           <damping>0.004</damping>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -449,7 +446,6 @@
         <dynamics>
           <damping>0.004</damping>
         </dynamics>
-        <use_parent_model_frame>1</use_parent_model_frame>
       </axis>
       <physics>
         <ode>

--- a/models/parachute_small/model.config
+++ b/models/parachute_small/model.config
@@ -2,8 +2,8 @@
 
 <model>
   <name>Parachute small</name>
-  <version>1.0</version>
-  <sdf version="1.7">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
   <license>Apache License, Version 2.0</license>
   <author>
     <name>Aurelien Roy</name>

--- a/models/parachute_small/model.sdf
+++ b/models/parachute_small/model.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <model name="parachute_small">
     <pose>0 0 0 0 0 0</pose>
     <link name="chute">

--- a/models/runway/model.config
+++ b/models/runway/model.config
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <model>
   <name>Runway</name>
-  <version>1.0</version>
-  <sdf version="1.7">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
 
   <author>
     <name>Rhys Mainwaring</name>

--- a/models/runway/model.sdf
+++ b/models/runway/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version="1.7">
+<sdf version="1.9">
   <model name="runway">
     <static>true</static>
     <link name="link">

--- a/models/zephyr/model.config
+++ b/models/zephyr/model.config
@@ -2,8 +2,8 @@
 
 <model>
   <name>Zephyr Delta Wing</name>
-  <version>1.0</version>
-  <sdf version="1.7">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
 
   <author>
     <name>Cole Biesemeyer</name>

--- a/models/zephyr/model.sdf
+++ b/models/zephyr/model.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <model name="zephyr">
     <link name="wing">
       <inertial>

--- a/models/zephyr_with_ardupilot/model.config
+++ b/models/zephyr_with_ardupilot/model.config
@@ -2,8 +2,8 @@
 
 <model>
   <name>Zephyr Delta Wing With Ardupilot</name>
-  <version>1.0</version>
-  <sdf version="1.7">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
 
   <author>
     <name>Cole Biesemeyer</name>

--- a/models/zephyr_with_ardupilot/model.sdf
+++ b/models/zephyr_with_ardupilot/model.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <model name="zephyr_with_ardupilot">
     <include>
       <uri>model://zephyr</uri>

--- a/models/zephyr_with_parachute/model.config
+++ b/models/zephyr_with_parachute/model.config
@@ -2,8 +2,8 @@
 
 <model>
   <name>Zephyr Delta Wing With Parachute</name>
-  <version>1.0</version>
-  <sdf version="1.7">model.sdf</sdf>
+  <version>2.0</version>
+  <sdf version="1.9">model.sdf</sdf>
 
   <author>
     <name>Cole Biesemeyer</name>

--- a/models/zephyr_with_parachute/model.sdf
+++ b/models/zephyr_with_parachute/model.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <model name="zephyr_with_parachute">
     <include>
       <uri>model://zephyr</uri>

--- a/tests/worlds/test_anemometer.sdf
+++ b/tests/worlds/test_anemometer.sdf
@@ -18,7 +18,7 @@
   MANUAL> module load sail
 
 -->
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="test_anemometer">
     <physics name="1ms" type="ignored">
       <max_step_size>0.001</max_step_size>

--- a/tests/worlds/test_gimbal.sdf
+++ b/tests/worlds/test_gimbal.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="test_gimbal">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>

--- a/tests/worlds/test_nested_model.sdf
+++ b/tests/worlds/test_nested_model.sdf
@@ -13,7 +13,7 @@
   gz topic -t "/rotor3_cmd" -m gz.msgs.Double -p "data: 1"
  -->
 
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="test_nested_model">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>

--- a/tests/worlds/test_parachute.sdf
+++ b/tests/worlds/test_parachute.sdf
@@ -17,7 +17,7 @@
   gz topic -t /parachute/cmd_release -m gz.msgs.Double -p 'data:1.0'
 
 -->
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="test_parachute">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>

--- a/worlds/iris_runway.sdf
+++ b/worlds/iris_runway.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="iris_runway">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>

--- a/worlds/iris_warehouse.sdf
+++ b/worlds/iris_warehouse.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="iris_warehouse">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>

--- a/worlds/zephyr_parachute.sdf
+++ b/worlds/zephyr_parachute.sdf
@@ -91,7 +91,7 @@
   FBWA>   auto            # switch to auto
   AUTO>   rc 9 1900       # manual parachute release
 -->
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="zephyr_runway">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>

--- a/worlds/zephyr_runway.sdf
+++ b/worlds/zephyr_runway.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
+<sdf version="1.9">
   <world name="zephyr_runway">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>


### PR DESCRIPTION
Upgrade models to SDF version 1.9.

The [`merge`](http://sdformat.org/tutorials?tut=composition_merge_proposal&cat=pose_semantics_docs&) attribute is required to support composed models in [`sdformat_urdf`](https://github.com/ros/sdformat_urdf).

## Details

- Update to SDF version 1.9.
- Update `model.config` `<version>` number.
- Remove element `<use_parent_model_frame>`

## Testing

Tested iris, iris with gimbal and zephyr models with ArduPilot [master: d3f2309](https://github.com/ArduPilot/ardupilot/commit/d3f2309eac1bf522720d27b3a22c242d32e2a6cd).