### PR TITLE
Models: correct transform from ENU to NED

### DIFF
--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -792,7 +792,7 @@
         Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates
       -->
       <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>iris_with_standoffs::imu_link::imu_sensor</imuName>

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -196,7 +196,7 @@
         Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates
       -->
       <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>iris_with_standoffs::imu_link::imu_sensor</imuName>

--- a/models/runway/model.sdf
+++ b/models/runway/model.sdf
@@ -11,7 +11,7 @@
         </geometry>
       </collision>
       <visual name="runway">
-        <pose>0 0 0 0 0 3.141592653589793</pose>
+        <pose degrees="true">0 0 0 0 0 90</pose>
         <cast_shadows>false</cast_shadows>
         <geometry>
           <plane>

--- a/models/zephyr_with_ardupilot/model.sdf
+++ b/models/zephyr_with_ardupilot/model.sdf
@@ -171,7 +171,7 @@
         Zephyr is oriented x-left, y-back, z-up
       -->
       <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 -1.5707963</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>zephyr::imu_link::imu_sensor</imuName>

--- a/models/zephyr_with_parachute/model.sdf
+++ b/models/zephyr_with_parachute/model.sdf
@@ -203,7 +203,7 @@
         Zephyr is oriented x-left, y-back, z-up
       -->
       <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 -1.5707963</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>zephyr::imu_link::imu_sensor</imuName>

--- a/tests/worlds/test_anemometer.sdf
+++ b/tests/worlds/test_anemometer.sdf
@@ -39,11 +39,14 @@
     <plugin filename="gz-sim-user-commands-system"
         name="gz::sim::systems::UserCommands">
     </plugin>
+    <plugin filename="asv_sim2-anemometer-system"
+      name="gz::sim::systems::Anemometer">
+    </plugin>
     <plugin filename="gz-sim-imu-system"
         name="gz::sim::systems::Imu">
     </plugin>
-    <plugin filename="asv_sim2-anemometer-system"
-      name="gz::sim::systems::Anemometer">
+    <plugin filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
     </plugin>
 
     <scene>
@@ -53,9 +56,9 @@
     </scene>
 
     <spherical_coordinates>
-      <latitude_deg>51.56991349023042</latitude_deg>
-      <longitude_deg>-4.033693921107272</longitude_deg>
-      <elevation>10.0</elevation>
+      <latitude_deg>-35.363262</latitude_deg>
+      <longitude_deg>149.165237</longitude_deg>
+      <elevation>584</elevation>
       <heading_deg>0</heading_deg>
       <surface_model>EARTH_WGS84</surface_model>
     </spherical_coordinates>
@@ -85,10 +88,10 @@
             </box>
           </geometry>
           <material>
-            <ambient>1 0 0 1</ambient>
-            <diffuse>1 0 0 1</diffuse>
-            <emissive>1 0 0 1</emissive>
-            <specular>0.5 0.5 0.5 1</specular>
+            <ambient>1 0 0 0.8</ambient>
+            <diffuse>1 0 0 0.8</diffuse>
+            <emissive>1 0 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
           </material>
         </visual>
         <visual name="g">
@@ -100,10 +103,10 @@
             </box>
           </geometry>
           <material>
-            <ambient>0 1 0 1</ambient>
-            <diffuse>0 1 0 1</diffuse>
-            <emissive>0 1 0 1</emissive>
-            <specular>0.5 0.5 0.5 1</specular>
+            <ambient>0 1 0 0.8</ambient>
+            <diffuse>0 1 0 0.8</diffuse>
+            <emissive>0 1 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
           </material>
         </visual>
         <visual name="b">
@@ -115,12 +118,16 @@
             </box>
           </geometry>
           <material>
-            <ambient>0 0 1 1</ambient>
-            <diffuse>0 0 1 1</diffuse>
-            <emissive>0 0 1 1</emissive>
-            <specular>0.5 0.5 0.5 1</specular>
+            <ambient>0 0 1 0.8</ambient>
+            <diffuse>0 0 1 0.8</diffuse>
+            <emissive>0 0 1 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
           </material>
         </visual>
+        <sensor name="navsat_sensor" type="navsat">
+          <always_on>1</always_on>
+          <update_rate>1</update_rate>
+        </sensor>
       </link>
     </model>
 
@@ -152,7 +159,7 @@
     </model>
 
     <model name="anemometer">
-      <pose>0 0 0.5 0 0 1.57079632</pose>
+      <pose degrees="true">0 0 0.5 0 0 90</pose>
       <link name="base_link">
         <inertial>
           <mass>10</mass>
@@ -213,7 +220,7 @@
           </inertia>
         </inertial>
         <sensor name="imu_sensor" type="imu">
-          <pose>0 0 0 3.141593 0 0</pose>
+          <pose degrees="true">0 0 0 180 0 0</pose>
           <always_on>1</always_on>
           <update_rate>1000.0</update_rate>
         </sensor>

--- a/tests/worlds/test_gimbal.sdf
+++ b/tests/worlds/test_gimbal.sdf
@@ -46,16 +46,17 @@
 
     <include>
       <uri>model://runway</uri>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
     </include>
 
     <!-- gimbal  -->
     <!-- <include>
       <uri>model://gimbal_small_2d</uri>
       <name>gimbal</name>
-      <pose>0 0 0.11 -1.57 0 1.57</pose>
+      <pose degrees="true">0 0 0.11 -90 0 90</pose>
       <plugin
-        filename="gz-sim-joint-position-controller2-system"
-        name="gz::sim::systems::JointPositionController2">
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
         <joint_name>arm_joint</joint_name>
         <topic>arm_cmd</topic>
         <p_gain>2</p_gain>
@@ -67,8 +68,8 @@
         <cmd_min>-1000</cmd_min>
       </plugin>
       <plugin
-        filename="gz-sim-joint-position-controller2-system"
-        name="gz::sim::systems::JointPositionController2">
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
         <joint_name>tilt_joint</joint_name>
         <topic>tilt_cmd</topic>
         <p_gain>2</p_gain>
@@ -83,7 +84,7 @@
 
     <!-- nested -->
     <model name="model2">
-      <pose>2 0 0.5 0 0 0</pose>
+      <pose degrees="true">0 0 0.5 0 0 90</pose>
       <link name="base_link">
         <inertial>
           <mass>0.25</mass>
@@ -120,7 +121,7 @@
       <include>
         <uri>model://gimbal_small_2d</uri>
         <name>gimbal</name>
-        <pose>0 0 0.61 -1.57 0 1.57</pose>
+        <pose degrees="true">0 0 0.61 -90 0 -90</pose>
       </include>
       <joint name="gimbal_joint" type="revolute">
         <parent>base_link</parent>
@@ -141,17 +142,17 @@
         name="gz::sim::systems::JointStatePublisher">
       </plugin>
       <plugin
-        filename="gz-sim-joint-position-controller2-system"
-        name="gz::sim::systems::JointPositionController2">
-        <joint_name>gimbal::arm_joint</joint_name>
-        <topic>arm_cmd</topic>
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>gimbal::roll_joint</joint_name>
+        <topic>cmd_roll</topic>
         <p_gain>2</p_gain>
       </plugin>
       <plugin
-        filename="gz-sim-joint-position-controller2-system"
-        name="gz::sim::systems::JointPositionController2">
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
         <joint_name>gimbal::tilt_joint</joint_name>
-        <topic>tilt_cmd</topic>
+        <topic>cmd_pitch</topic>
         <p_gain>2</p_gain>
       </plugin>
 

--- a/tests/worlds/test_parachute.sdf
+++ b/tests/worlds/test_parachute.sdf
@@ -55,10 +55,11 @@
 
     <include>
       <uri>model://runway</uri>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
     </include>
 
     <model name="payload">
-      <pose>0 0 50 0 0 0</pose>
+      <pose degrees="true">0 0 50 0 0 90</pose>
       <link name="base_link">
         <inertial>
           <mass>0.25</mass>
@@ -129,7 +130,7 @@
         <parent>base_link</parent>
       </joint>
 
-      <plugin filename="libParachutePlugin.so" name="ParachutePlugin">
+      <plugin filename="ParachutePlugin" name="ParachutePlugin">
         <parent_link>attachment_link</parent_link>
         <child_model>parachute_small</child_model>
         <child_link>chute</child_link>

--- a/worlds/iris_runway.sdf
+++ b/worlds/iris_runway.sdf
@@ -46,10 +46,12 @@
 
     <include>
       <uri>model://runway</uri>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
     </include>
 
     <include>
       <uri>model://iris_with_ardupilot</uri>
+      <pose degrees="true">0 0 0 0 0 90</pose>
     </include>
 
   </world>

--- a/worlds/iris_runway.sdf
+++ b/worlds/iris_runway.sdf
@@ -23,12 +23,23 @@
     <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
+    <plugin filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
+    </plugin>
 
     <scene>
       <ambient>1.0 1.0 1.0</ambient>
       <background>0.8 0.8 0.8</background>
       <sky></sky>
     </scene>
+
+    <spherical_coordinates>
+      <latitude_deg>-35.363262</latitude_deg>
+      <longitude_deg>149.165237</longitude_deg>
+      <elevation>584</elevation>
+      <heading_deg>0</heading_deg>
+      <surface_model>EARTH_WGS84</surface_model>
+    </spherical_coordinates>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -44,6 +55,61 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
+    <model name="axes">
+      <static>1</static>
+      <link name="link">
+        <visual name="r">
+          <cast_shadows>0</cast_shadows>
+          <pose>5 0 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 0.01 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 0.8</ambient>
+            <diffuse>1 0 0 0.8</diffuse>
+            <emissive>1 0 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <visual name="g">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 5 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 10 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 0.8</ambient>
+            <diffuse>0 1 0 0.8</diffuse>
+            <emissive>0 1 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <visual name="b">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 0 5.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 0.01 10</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 0.8</ambient>
+            <diffuse>0 0 1 0.8</diffuse>
+            <emissive>0 0 1 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <sensor name="navsat_sensor" type="navsat">
+          <always_on>1</always_on>
+          <update_rate>1</update_rate>
+        </sensor>
+      </link>
+    </model>
+    
     <include>
       <uri>model://runway</uri>
       <pose degrees="true">-29 545 0 0 0 363</pose>

--- a/worlds/zephyr_parachute.sdf
+++ b/worlds/zephyr_parachute.sdf
@@ -110,12 +110,23 @@
     <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
+    <plugin filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
+    </plugin>
 
     <scene>
       <ambient>1.0 1.0 1.0</ambient>
       <background>0.8 0.8 0.8</background>
       <sky></sky>
     </scene>
+
+    <spherical_coordinates>
+      <latitude_deg>-35.363262</latitude_deg>
+      <longitude_deg>149.165237</longitude_deg>
+      <elevation>584</elevation>
+      <heading_deg>0</heading_deg>
+      <surface_model>EARTH_WGS84</surface_model>
+    </spherical_coordinates>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -131,6 +142,61 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
+    <model name="axes">
+      <static>1</static>
+      <link name="link">
+        <visual name="r">
+          <cast_shadows>0</cast_shadows>
+          <pose>5 0 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 0.01 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 0.8</ambient>
+            <diffuse>1 0 0 0.8</diffuse>
+            <emissive>1 0 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <visual name="g">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 5 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 10 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 0.8</ambient>
+            <diffuse>0 1 0 0.8</diffuse>
+            <emissive>0 1 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <visual name="b">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 0 5.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 0.01 10</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 0.8</ambient>
+            <diffuse>0 0 1 0.8</diffuse>
+            <emissive>0 0 1 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <sensor name="navsat_sensor" type="navsat">
+          <always_on>1</always_on>
+          <update_rate>1</update_rate>
+        </sensor>
+      </link>
+    </model>
+    
     <include>
       <uri>model://runway</uri>
       <pose degrees="true">-29 545 0 0 0 363</pose>

--- a/worlds/zephyr_parachute.sdf
+++ b/worlds/zephyr_parachute.sdf
@@ -133,11 +133,12 @@
 
     <include>
       <uri>model://runway</uri>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
     </include>
 
     <include>
-      <pose>0 0 0.422 -1.5707963 0 1.5707963</pose>
       <uri>model://zephyr_with_parachute</uri>
+      <pose degrees="true">0 0 0.422 -90 0 180</pose>
 
       <plugin filename="libParachutePlugin.so" name="ParachutePlugin">
         <parent_link>parachute_attachment_link</parent_link>

--- a/worlds/zephyr_runway.sdf
+++ b/worlds/zephyr_runway.sdf
@@ -41,11 +41,12 @@
 
     <include>
       <uri>model://runway</uri>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
     </include>
 
     <include>
-      <pose>0 0 0.422 -1.5707963 0 1.5707963</pose>
       <uri>model://zephyr_with_ardupilot</uri>
+      <pose degrees="true">0 0 0.422 -90 0 180</pose>
     </include>
 
   </world>

--- a/worlds/zephyr_runway.sdf
+++ b/worlds/zephyr_runway.sdf
@@ -18,12 +18,23 @@
     <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
+    <plugin filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
+    </plugin>
 
     <scene>
       <ambient>1.0 1.0 1.0</ambient>
       <background>0.8 0.8 0.8</background>
       <sky></sky>
     </scene>
+
+    <spherical_coordinates>
+      <latitude_deg>-35.363262</latitude_deg>
+      <longitude_deg>149.165237</longitude_deg>
+      <elevation>584</elevation>
+      <heading_deg>0</heading_deg>
+      <surface_model>EARTH_WGS84</surface_model>
+    </spherical_coordinates>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
@@ -38,6 +49,61 @@
       </attenuation>
       <direction>-0.5 0.1 -0.9</direction>
     </light>
+
+    <model name="axes">
+      <static>1</static>
+      <link name="link">
+        <visual name="r">
+          <cast_shadows>0</cast_shadows>
+          <pose>5 0 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 0.01 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 0.8</ambient>
+            <diffuse>1 0 0 0.8</diffuse>
+            <emissive>1 0 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <visual name="g">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 5 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 10 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 0.8</ambient>
+            <diffuse>0 1 0 0.8</diffuse>
+            <emissive>0 1 0 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <visual name="b">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 0 5.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 0.01 10</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 0.8</ambient>
+            <diffuse>0 0 1 0.8</diffuse>
+            <emissive>0 0 1 0.8</emissive>
+            <specular>0.5 0.5 0.5 0.8</specular>
+          </material>
+        </visual>
+        <sensor name="navsat_sensor" type="navsat">
+          <always_on>1</always_on>
+          <update_rate>1</update_rate>
+        </sensor>
+      </link>
+    </model>
 
     <include>
       <uri>model://runway</uri>


### PR DESCRIPTION
Correct the rotation in the plugin XML element `< gazeboXYZToNED >` that maps between the world frames used in Gazebo and ArduPilot. The missing rotation is apparent when specifying the world origin geolocation with the `<spherical_coordinates>` element and using and navsat sensor.

Closes #58

## Detail

- Gazebo uses the ENU convention for world frames, ArduPilot uses NED.
- Add the missing z-axis rotation to the element `< gazeboXYZToNED >`.
- Update the vehicle initial world pose so model is initially oriented north.
- Add navsat sensors and system so location may be visualised with the Gazebo NavSat GUI tool.
- Add axes models to example worlds to aid orientation.