### PR TITLE
Iris: set base_link as mobile base in odometry publisher

### DIFF
--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -40,8 +40,8 @@
     <plugin
       filename="gz-sim-odometry-publisher-system"
       name="gz::sim::systems::OdometryPublisher">
-      <odom_frame>iris/odom</odom_frame>
-      <robot_base_frame>iris</robot_base_frame>
+      <odom_frame>odom</odom_frame>
+      <robot_base_frame>base_link</robot_base_frame>
       <dimensions>3</dimensions>
     </plugin>
     <plugin filename="gz-sim-lift-drag-system"


### PR DESCRIPTION
Update the odom and robot frames for the `OdometryPublisher` plugin to conform with [ROS REP 105](https://www.ros.org/reps/rep-0105.html).

- Remove the frame prefix in `<odom_frame>`.
- Change `<robot_base_frame >` to `base_link`.

Required to fix: https://github.com/ArduPilot/ardupilot_gz/issues/30