### PR TITLE
Models: fix world orientation

### DIFF
--- a/models/gimbal_small_1d/model.sdf
+++ b/models/gimbal_small_1d/model.sdf
@@ -108,7 +108,7 @@
         </geometry>
       </collision>
       <sensor name="camera" type="camera">
-        <pose>0 0 0 -1.57 -1.57 0</pose>
+        <pose degrees="true">0 0 0 -90 -90 0</pose>
         <camera>
           <horizontal_fov>2.0</horizontal_fov>
           <image>

--- a/models/gimbal_small_2d/model.sdf
+++ b/models/gimbal_small_2d/model.sdf
@@ -144,7 +144,7 @@
         </geometry>
       </collision>
       <sensor name="camera" type="camera">
-        <pose>0 0 0 -1.57 -1.57 0</pose>
+        <pose degrees="true">0 0 0 -90 -90 0</pose>
         <camera>
           <horizontal_fov>2.0</horizontal_fov>
           <image>

--- a/models/iris_with_ardupilot/model.sdf
+++ b/models/iris_with_ardupilot/model.sdf
@@ -79,9 +79,9 @@
     </link>
     <link name="rotor_0_blade_2_cp">
       <gravity>0</gravity>
-      <pose>0.13 -0.22 0.216 0 -0 0</pose>
+      <pose>0.13 -0.22 0.216 0 0 0</pose>
       <visual name='rotor_0_visual_root'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -93,7 +93,7 @@
         </material>
       </visual>
       <visual name='rotor_0_visual_tip'>
-        <pose>-0.12 0 0 0 -0 0</pose>
+        <pose>-0.12 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -105,7 +105,7 @@
         </material>
       </visual>
       <visual name='rotor_0_visual_cp'>
-        <pose>-0.084 0 0 0 -0 0</pose>
+        <pose>-0.084 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -117,7 +117,7 @@
         </material>
       </visual>
       <visual name='rotor_0_visual_cp_forward'>
-        <pose>-0.084 -0.02 0 0 -0 0</pose>
+        <pose>-0.084 -0.02 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -129,7 +129,7 @@
         </material>
       </visual>
       <visual name='rotor_0_visual_cp_upward'>
-        <pose>-0.084 0 0.02 0 -0 0</pose>
+        <pose>-0.084 0 0.02 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -166,9 +166,9 @@
 
     <link name="rotor_1_blade_1_cp">
       <gravity>0</gravity>
-      <pose>-0.13 0.2 0.216 0 -0 0</pose>
+      <pose>-0.13 0.2 0.216 0 0 0</pose>
       <visual name='rotor_1_visual_root'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -180,7 +180,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_tip'>
-        <pose>0.12 0 0 0 -0 0</pose>
+        <pose>0.12 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -192,7 +192,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_cp'>
-        <pose>0.084 0 0 0 -0 0</pose>
+        <pose>0.084 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -204,7 +204,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_cp_forward'>
-        <pose>0.084 0.02 0 0 -0 0</pose>
+        <pose>0.084 0.02 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -216,7 +216,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_cp_upward'>
-        <pose>0.084 0 0.02 0 -0 0</pose>
+        <pose>0.084 0 0.02 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -230,9 +230,9 @@
     </link>
     <link name="rotor_1_blade_2_cp">
       <gravity>0</gravity>
-      <pose>-0.13 0.2 0.216 0 -0 0</pose>
+      <pose>-0.13 0.2 0.216 0 0 0</pose>
       <visual name='rotor_1_visual_root'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -244,7 +244,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_tip'>
-        <pose>-0.12 0 0 0 -0 0</pose>
+        <pose>-0.12 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -256,7 +256,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_cp'>
-        <pose>-0.084 0 0 0 -0 0</pose>
+        <pose>-0.084 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -268,7 +268,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_cp_forward'>
-        <pose>-0.084 -0.02 0 0 -0 0</pose>
+        <pose>-0.084 -0.02 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -280,7 +280,7 @@
         </material>
       </visual>
       <visual name='rotor_1_visual_cp_upward'>
-        <pose>-0.084 0 0.02 0 -0 0</pose>
+        <pose>-0.084 0 0.02 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -317,9 +317,9 @@
 
     <link name="rotor_2_blade_1_cp">
       <gravity>0</gravity>
-      <pose>0.13 0.22 0.216 0 -0 0</pose>
+      <pose>0.13 0.22 0.216 0 0 0</pose>
       <visual name='rotor_2_visual_root'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -331,7 +331,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_tip'>
-        <pose>0.12 0 0 0 -0 0</pose>
+        <pose>0.12 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -343,7 +343,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_cp'>
-        <pose>0.084 0 0 0 -0 0</pose>
+        <pose>0.084 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -355,7 +355,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_cp_forward'>
-        <pose>0.084 -0.02 0 0 -0 0</pose>
+        <pose>0.084 -0.02 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -367,7 +367,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_cp_upward'>
-        <pose>0.084 0 0.02 0 -0 0</pose>
+        <pose>0.084 0 0.02 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -381,9 +381,9 @@
     </link>
     <link name="rotor_2_blade_2_cp">
       <gravity>0</gravity>
-      <pose>0.13 0.22 0.216 0 -0 0</pose>
+      <pose>0.13 0.22 0.216 0 0 0</pose>
       <visual name='rotor_2_visual_root'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -395,7 +395,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_tip'>
-        <pose>-0.12 0 0 0 -0 0</pose>
+        <pose>-0.12 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -407,7 +407,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_cp'>
-        <pose>-0.084 0 0 0 -0 0</pose>
+        <pose>-0.084 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -419,7 +419,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_cp_forward'>
-        <pose>-0.084 0.02 0 0 -0 0</pose>
+        <pose>-0.084 0.02 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -431,7 +431,7 @@
         </material>
       </visual>
       <visual name='rotor_2_visual_cp_upward'>
-        <pose>-0.084 0 0.02 0 -0 0</pose>
+        <pose>-0.084 0 0.02 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -468,9 +468,9 @@
 
     <link name="rotor_3_blade_1_cp">
       <gravity>0</gravity>
-      <pose>-0.13 -0.2 0.216 0 -0 0</pose>
+      <pose>-0.13 -0.2 0.216 0 0 0</pose>
       <visual name='rotor_3_visual_root'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -482,7 +482,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_tip'>
-        <pose>0.12 0 0 0 -0 0</pose>
+        <pose>0.12 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -494,7 +494,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_cp'>
-        <pose>0.084 0 0 0 -0 0</pose>
+        <pose>0.084 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -506,7 +506,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_cp_forward'>
-        <pose>0.084 -0.02 0 0 -0 0</pose>
+        <pose>0.084 -0.02 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -518,7 +518,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_cp_upward'>
-        <pose>0.084 0 0.02 0 -0 0</pose>
+        <pose>0.084 0 0.02 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -532,9 +532,9 @@
     </link>
     <link name="rotor_3_blade_2_cp">
       <gravity>0</gravity>
-      <pose>-0.13 -0.2 0.216 0 -0 0</pose>
+      <pose>-0.13 -0.2 0.216 0 0 0</pose>
       <visual name='rotor_3_visual_root'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -546,7 +546,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_tip'>
-        <pose>-0.12 0 0 0 -0 0</pose>
+        <pose>-0.12 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -558,7 +558,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_cp'>
-        <pose>-0.084 0 0 0 -0 0</pose>
+        <pose>-0.084 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -570,7 +570,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_cp_forward'>
-        <pose>-0.084 0.02 0 0 -0 0</pose>
+        <pose>-0.084 0.02 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -582,7 +582,7 @@
         </material>
       </visual>
       <visual name='rotor_3_visual_cp_upward'>
-        <pose>-0.084 0 0.02 0 -0 0</pose>
+        <pose>-0.084 0 0.02 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.003</radius>
@@ -791,8 +791,8 @@
       <!-- Frame conventions
         Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates
       -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>iris_with_standoffs::imu_link::imu_sensor</imuName>

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -8,7 +8,7 @@
     <include>
       <uri>model://gimbal_small_2d</uri>
       <name>gimbal</name>
-      <pose>0 -0.01 0.070 1.57 0 1.57</pose>    
+      <pose degrees="true">0 -0.01 -0.124923 90 0 90</pose>    
     </include>
 
     <joint name="gimbal_joint" type="revolute">
@@ -195,8 +195,8 @@
       <!-- Frame conventions
         Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates
       -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>iris_with_standoffs::imu_link::imu_sensor</imuName>

--- a/models/iris_with_standoffs/model.sdf
+++ b/models/iris_with_standoffs/model.sdf
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <sdf version='1.9'>
   <model name='iris_with_standoffs'>
-    <pose>0 0 0.194923 0 0 0</pose>
+    <pose>0 0 0 0 0 0</pose>
     <link name='base_link'>
       <velocity_decay>
         <linear>0.0</linear>
@@ -155,7 +155,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -177,9 +177,9 @@
       </axis>
     </joint>
     <link name='rotor_0'>
-      <pose>0.13 -0.22 0.023 0 -0 0</pose>
+      <pose>0.13 -0.22 0.023 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
         <inertia>
           <ixx>9.75e-06</ixx>
@@ -191,7 +191,7 @@
         </inertia>
       </inertial>
       <collision name='rotor_0_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.005</length>
@@ -208,7 +208,7 @@
         </surface>
       </collision>
       <visual name='rotor_0_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -251,9 +251,9 @@
       </physics>
     </joint>
     <link name='rotor_1'>
-      <pose>-0.13 0.2 0.023 0 -0 0</pose>
+      <pose>-0.13 0.2 0.023 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
         <inertia>
           <ixx>9.75e-06</ixx>
@@ -265,7 +265,7 @@
         </inertia>
       </inertial>
       <collision name='rotor_1_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.005</length>
@@ -282,7 +282,7 @@
         </surface>
       </collision>
       <visual name='rotor_1_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -325,9 +325,9 @@
       </physics>
     </joint>
     <link name='rotor_2'>
-      <pose>0.13 0.22 0.023 0 -0 0</pose>
+      <pose>0.13 0.22 0.023 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
         <inertia>
           <ixx>9.75e-06</ixx>
@@ -339,7 +339,7 @@
         </inertia>
       </inertial>
       <collision name='rotor_2_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.005</length>
@@ -356,7 +356,7 @@
         </surface>
       </collision>
       <visual name='rotor_2_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -399,9 +399,9 @@
       </physics>
     </joint>
     <link name='rotor_3'>
-      <pose>-0.13 -0.2 0.023 0 -0 0</pose>
+      <pose>-0.13 -0.2 0.023 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
         <inertia>
           <ixx>9.75e-06</ixx>
@@ -413,7 +413,7 @@
         </inertia>
       </inertial>
       <collision name='rotor_3_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.005</length>
@@ -430,7 +430,7 @@
         </surface>
       </collision>
       <visual name='rotor_3_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>

--- a/models/parachute_small/model.sdf
+++ b/models/parachute_small/model.sdf
@@ -47,8 +47,8 @@
         </material>
       </visual>
     </link>
-    <plugin filename="libgz-sim-lift-drag-system.so"
-        name="gz::sim::systems::LiftDrag">
+    <plugin name="gz::sim::systems::LiftDrag"
+        filename="gz-sim-lift-drag-system">
       <a0>0</a0>
       <cla>0</cla>
       <cda>1.75</cda>  <!-- Such that Cd = 1.75 at alpha = 90deg (= upright parachute) -->

--- a/models/zephyr/model.sdf
+++ b/models/zephyr/model.sdf
@@ -96,7 +96,7 @@
 
     </link>
     <link name="propeller">
-      <pose>0 0.07 0.008 0 1.5707 0</pose>
+      <pose degrees="true">0 0.07 0.008 0 90 0</pose>
       <inertial>
         <mass>.05</mass>
         <inertia>
@@ -260,7 +260,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 -1.5707963</pose>
+        <pose degrees="true">0 0 0 180 0 -90</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>

--- a/models/zephyr_with_ardupilot/model.sdf
+++ b/models/zephyr_with_ardupilot/model.sdf
@@ -19,7 +19,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0 -0.1 0</cp>
       <area>0.50</area>
       <air_density>1.2041</air_density>
@@ -37,7 +37,7 @@
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.7 0.20 0</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -57,7 +57,7 @@
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.7 0.20 0</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -77,7 +77,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.76 0.30 0.025</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -95,7 +95,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.76 0.30 0.025</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -170,8 +170,8 @@
 
         Zephyr is oriented x-left, y-back, z-up
       -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 -1.5707963</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 -90</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>zephyr::imu_link::imu_sensor</imuName>

--- a/models/zephyr_with_parachute/model.sdf
+++ b/models/zephyr_with_parachute/model.sdf
@@ -11,7 +11,7 @@
       must be fixed.
     -->
     <link name="parachute_attachment_link">
-      <pose>0 0 0.1 0 0 -1.5707963</pose>
+      <pose degrees="true">0 0 0.1 0 0 -90</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.1</mass>
@@ -51,7 +51,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0 -0.1 0</cp>
       <area>0.50</area>
       <air_density>1.2041</air_density>
@@ -69,7 +69,7 @@
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.7 0.20 0</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -89,7 +89,7 @@
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.7 0.20 0</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -109,7 +109,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.76 0.30 0.025</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -127,7 +127,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.76 0.30 0.025</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -202,8 +202,8 @@
 
         Zephyr is oriented x-left, y-back, z-up
       -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 -1.5707963</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 -90</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>zephyr::imu_link::imu_sensor</imuName>

--- a/tests/worlds/test_anemometer.sdf
+++ b/tests/worlds/test_anemometer.sdf
@@ -10,7 +10,7 @@
 
   SITL
 
-  sim_vehicle.py -D -v Rover -f JSON -/-console -/-map
+  sim_vehicle.py -D -v Rover -/-model JSON -/-console -/-map
 
   MANUAL> param set WNDVN_TYPE 11
   MANUAL> param set WNDVN_SPEED_TYPE 11
@@ -289,8 +289,8 @@
         <fdm_port_in>9002</fdm_port_in>
         <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
         <lock_step>1</lock_step>
-        <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
-        <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
+        <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
+        <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
         <imuName>imu_link::imu_sensor</imuName>
         <anemometer>anemometer_link::anemometer</anemometer>
       </plugin>

--- a/worlds/iris_runway.sdf
+++ b/worlds/iris_runway.sdf
@@ -117,7 +117,7 @@
 
     <include>
       <uri>model://iris_with_ardupilot</uri>
-      <pose degrees="true">0 0 0 0 0 90</pose>
+      <pose degrees="true">0 0 0.195 0 0 90</pose>
     </include>
 
   </world>

--- a/worlds/iris_warehouse.sdf
+++ b/worlds/iris_warehouse.sdf
@@ -267,44 +267,44 @@
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/fog emitter</uri>
     </include>
 
-    <!-- missing table (see below)
-    <include>
+    <!-- missing table (see below) -->
+    <!-- <include>
         <pose>-9.0 -1.8 1.038 0 0 0</pose>
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Panda with Ignition position controller model</uri>
     </include> -->
 
-    <!-- model has incorrect fuel server details
-    <include>
-        <pose>-9.0 -2.4 0 0 0 1.57</pose>
+    <!-- model has incorrect fuel server details -->
+    <!-- <include>
+        <pose degrees="true">-9.0 -2.4 0 0 0 90</pose>
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Reflective table</uri>
     </include> -->
 
-    <!-- model has incorrect fuel server details
-    <include>
-        <pose>-13.2 -6.0 0 0 0 1.57</pose>
+    <!-- model has incorrect fuel server details -->
+    <!-- <include>
+        <pose degrees="true">-13.2 -6.0 0 0 0 90</pose>
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Rescue Randy Sitting</uri>
     </include> -->
 
     <include>
-        <pose>-9.0 -6.21 5.0 0 0.9 -3.14</pose>
+        <pose degrees="true">-9.0 -6.21 5.0 0 51.5 -180</pose>
         <static>true</static>
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/16-Bit Thermal Camera</uri>
     </include>
 
     <include>
-        <pose>-9.0 -5.95 5.0 0 0.9 -3.14</pose>
+        <pose degrees="true">-9.0 -5.95 5.0 0 51.5 -180</pose>
         <static>true</static>
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/8-Bit Thermal Camera</uri>
     </include>
 
     <include>
-        <pose>-9.075 -6.15 4.995 0 0.9 -3.14</pose>
+        <pose degrees="true">-9.075 -6.15 4.995 0 51.5 -180</pose>
         <static>true</static>
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Camera</uri>
     </include>
 
-    <include>
-        <pose>-9.04 -6.04 4.97 0 0.9 -3.14</pose>
+    <include degrees="true">
+        <pose>-9.04 -6.04 4.97 0 51.5 -180</pose>
         <static>true</static>
         <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Depth Camera</uri>
     </include>

--- a/worlds/zephyr_parachute.sdf
+++ b/worlds/zephyr_parachute.sdf
@@ -78,7 +78,7 @@
   SITL
   ====
 
-  sim_vehicle.py -D -v ArduPlane -f gazebo-zephyr \-\-model JSON \-\-map \-\-console
+  sim_vehicle.py -D -v ArduPlane -f gazebo-zephyr -\-model JSON -\-map -\-console
 
   MAVProxy
   ========
@@ -206,7 +206,7 @@
       <uri>model://zephyr_with_parachute</uri>
       <pose degrees="true">0 0 0.422 -90 0 180</pose>
 
-      <plugin filename="libParachutePlugin.so" name="ParachutePlugin">
+      <plugin name="ParachutePlugin" filename="ParachutePlugin">
         <parent_link>parachute_attachment_link</parent_link>
         <child_model>parachute_small</child_model>
         <child_link>chute</child_link>


### PR DESCRIPTION
This PR reviews and fixes the orientation of models and worlds to ensure compliance with the conventions used by ROS and ArduPilot. 

- https://discuss.ardupilot.org/t/compass-settings-compasses-inconsistent-error/110592

**Edit** `<cma>` fix below moved to #73 

There is also a fix for planes on Harmonic where a change in behaviour of the LiftDrag plugin requires the moment coefficient `<cma>` to be set to zero in order to disable the adjustment (it was previously ignored).

- https://github.com/gazebosim/gz-sim/pull/2189

### Details

- Use degrees rather than radians in `<pose>` where this simplifies or clarifies the rotation.
- Replace `-0` with `0`. These arise where the SDF model had been originally generated from URDF.

### Checks

Models

- [x] gimbal_small_1d
- [x] gimbal_small_2d
- [x] iris_with_ardupilot
- [x] iris_with_gimbal
- [x] iris_with_standoffs
- [x] parachute_small
- [x] runway
- [x] zephyr
- [x] zephyr_with_ardupilot
- [x] zephyr_with_parachute

Worlds

- [x] iris_runway
- [x] iris_warehouse
- [x] zephyr_parachute
- [x] zephyr_runway

Tests

- [x] test_anemometer
- [x] test_gimbal
- [x] test_nested_model
- [x] test_parachute
