### PR TITLE
Runway: fix render order issue causing vehicle model to be hidden

### DIFF
--- a/models/runway/model.sdf
+++ b/models/runway/model.sdf
@@ -20,7 +20,6 @@
           </plane>
         </geometry>
         <material>
-          <render_order>10</render_order>
           <ambient>0.8 0.8 0.8 1</ambient>
           <diffuse>0.8 0.8 0.8 1</diffuse>
           <specular>0.1 0.1 0.1 1</specular>


### PR DESCRIPTION
Fix a render order issue that causes vehicle models to be hidden behind the runway.

See: https://community.gazebosim.org/t/graphic-artifacts-clipped-or-not-visible-drone/2510