### PR TITLE
Default to gazebo harmonic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # --------------------------------------------------------------------------- #
 # Find gz-sim and dependencies.
 
-# Harmonic
+# Harmonic (default)
 if("$ENV{GZ_VERSION}" STREQUAL "harmonic" OR NOT DEFINED "ENV{GZ_VERSION}")
   find_package(gz-cmake3 REQUIRED)
   set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
@@ -32,7 +32,7 @@ if("$ENV{GZ_VERSION}" STREQUAL "harmonic" OR NOT DEFINED "ENV{GZ_VERSION}")
   set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 
   message(STATUS "Compiling against Gazebo Harmonic")
-# Garden (default)
+# Garden
 elseif("$ENV{GZ_VERSION}" STREQUAL "garden")
   find_package(gz-cmake3 REQUIRED)
   set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Find gz-sim and dependencies.
 
 # Harmonic
-if("$ENV{GZ_VERSION}" STREQUAL "harmonic")
+if("$ENV{GZ_VERSION}" STREQUAL "harmonic" OR NOT DEFINED "ENV{GZ_VERSION}")
   find_package(gz-cmake3 REQUIRED)
   set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 
@@ -33,7 +33,7 @@ if("$ENV{GZ_VERSION}" STREQUAL "harmonic")
 
   message(STATUS "Compiling against Gazebo Harmonic")
 # Garden (default)
-elseif("$ENV{GZ_VERSION}" STREQUAL "garden" OR NOT DEFINED "ENV{GZ_VERSION}")
+elseif("$ENV{GZ_VERSION}" STREQUAL "garden")
   find_package(gz-cmake3 REQUIRED)
   set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The project comprises a Gazebo plugin to connect to ArduPilot SITL
 ## Prerequisites
 
 Gazebo Garden or Harmonic is supported on Ubuntu 22.04 (Jammy).
+Harmonic is recommended.
 If you are running Ubuntu as a virtual machine you will need at least
 Ubuntu 20.04 in order to have the OpenGL support required for the
 `ogre2` render engine. Gazebo and ArduPilot SITL will also run on macOS
@@ -43,14 +44,27 @@ Install additional dependencies:
 
 ### Ubuntu
 
-Gazebo Garden:
+Recommended - Use rosdep with
+[osrf's rosdep rules](https://github.com/osrf/osrf-rosdep?tab=readme-ov-file#1-use-rosdep-to-resolve-gazebo-libraries)
+to manage all dependencies. This is driven off of the environment variable `GZ_VERSION`.
+
+```bash
+export GZ_VERSION=harmonic # or garden
+sudo bash -c 'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list'
+rosdep update
+rosdep resolve gz-harmonic
+# Navigate to your ROS workspace before the next command.
+rosdep install --from-paths src --ignore-src -y
+```
+
+Manual - Gazebo Garden Dependencies:
 
 ```bash
 sudo apt update
 sudo apt install libgz-sim7-dev rapidjson-dev
 ```
 
-Or Gazebo Harmonic:
+Manual - Gazebo Harmonic Dependencies:
 
 ```bash
 sudo apt update

--- a/README.md
+++ b/README.md
@@ -44,18 +44,7 @@ Install additional dependencies:
 
 ### Ubuntu
 
-Recommended - Use rosdep with
-[osrf's rosdep rules](https://github.com/osrf/osrf-rosdep?tab=readme-ov-file#1-use-rosdep-to-resolve-gazebo-libraries)
-to manage all dependencies. This is driven off of the environment variable `GZ_VERSION`.
-
-```bash
-export GZ_VERSION=harmonic # or garden
-sudo bash -c 'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list'
-rosdep update
-rosdep resolve gz-harmonic
-# Navigate to your ROS workspace before the next command.
-rosdep install --from-paths src --ignore-src -y
-```
+#### Garden (apt)
 
 Manual - Gazebo Garden Dependencies:
 
@@ -64,11 +53,28 @@ sudo apt update
 sudo apt install libgz-sim7-dev rapidjson-dev
 ```
 
+#### Harmonic (apt)
+
 Manual - Gazebo Harmonic Dependencies:
 
 ```bash
 sudo apt update
 sudo apt install libgz-sim8-dev rapidjson-dev
+```
+
+#### Rosdep
+
+Use rosdep with
+[osrf's rosdep rules](https://github.com/osrf/osrf-rosdep?tab=readme-ov-file#1-use-rosdep-to-resolve-gazebo-libraries)
+to manage all dependencies. This is driven off of the environment variable `GZ_VERSION`.
+
+```bash
+export GZ_VERSION=harmonic # or garden
+sudo bash -c 'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list'
+rosdep update
+rosdep resolve gz-harmonic # or gz-garden
+# Navigate to your ROS workspace before the next command.
+rosdep install --from-paths src --ignore-src -y
 ```
 
 ### macOS

--- a/package.xml
+++ b/package.xml
@@ -12,14 +12,14 @@
 
   <build_depend>rapidjson-dev</build_depend>  
 
-  <!-- Harmonic -->
+  <!-- Harmonic (default) -->
   <depend condition="$GZ_VERSION == harmonic">gz-cmake3</depend>
   <depend condition="$GZ_VERSION == harmonic">gz-sim8</depend>
-  <!-- Garden (default) -->
+  <depend condition="$GZ_VERSION == ''">gz-cmake3</depend>
+  <depend condition="$GZ_VERSION == ''">gz-sim8</depend>
+  <!-- Garden -->
   <depend condition="$GZ_VERSION == garden">gz-cmake3</depend>
   <depend condition="$GZ_VERSION == garden">gz-sim7</depend>
-  <depend condition="$GZ_VERSION == ''">gz-cmake3</depend>
-  <depend condition="$GZ_VERSION == ''">gz-sim7</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 


### PR DESCRIPTION
# Purpose

Update the default to install gazebo harmonic and recommend it, and use OSRF's rosdep registry to resolve the right version of the simulator.
