### PR TITLE
Iris: update iris_with_gimbal model to 3d gimbal

### DIFF
--- a/config/gazebo-iris-gimbal.parm
+++ b/config/gazebo-iris-gimbal.parm
@@ -2,29 +2,35 @@
 FRAME_CLASS	     1
 FRAME_TYPE	     1
 
-# IRLOCK FEATURE
-RC8_OPTION       39
-PLND_ENABLED     1
-PLND_TYPE        3
+# Match servo out for motors
+MOT_PWM_MIN      1100
+MOT_PWM_MAX      1900
 
-# SONAR FOR IRLOCK
-SIM_SONAR_SCALE  10
-RNGFND1_TYPE     1
-RNGFND1_SCALING  10
-RNGFND1_PIN      0
-RNGFND1_MAX_CM   5000
+# Gimbal on mount 1 has 3 DOF
+MNT1_TYPE        1           # Servo
+MNT1_PITCH_MAX   45
+MNT1_PITCH_MIN   -135
+MNT1_ROLL_MAX    30
+MNT1_ROLL_MIN    -30
+MNT1_YAW_MAX     160
+MNT1_YAW_MIN     -160
 
-# Gimbal on mount 1 has 2 DOF
-MNT1_PITCH_MAX   90
-MNT1_PITCH_MIN   -90
-MNT1_ROLL_MAX    90
-MNT1_ROLL_MIN    -90
-MNT1_TYPE        1
+# Gimbal RC in
+RC6_MAX          1900
+RC6_MIN          1100
+RC6_OPTION       212         # Mount1 Roll
+RC7_MAX          1900
+RC7_MIN          1100
+RC7_OPTION       213         # Mount1 Pitch
+RC8_MAX          1900
+RC8_MIN          1100
+RC8_OPTION       214         # Mount1 Yaw
+RC8_REVERSED     0           # Normal
+RC9_MAX          1900
+RC9_MIN          1100
+RC9_OPTION       0           # Do Nothing
 
-# Gimbal roll and pitch RC
-RC9_OPTION       212
-RC10_OPTION      213
-
-# Gimbal roll and pitch servos
-SERVO5_FUNCTION  8
-SERVO6_FUNCTION  7
+# Gimbal servo out
+SERVO9_FUNCTION  8           # Mount1Roll
+SERVO10_FUNCTION 7           # Mount1Pitch
+SERVO11_FUNCTION 6           # Mount1Yaw

--- a/models/gimbal_small_1d/model.sdf
+++ b/models/gimbal_small_1d/model.sdf
@@ -143,8 +143,8 @@
           <damping>0.5</damping>
         </dynamics>
         <limit>
-          <lower>-1.57079632</lower>
-          <upper>1.57079632</upper>
+          <lower>-3.1415926</lower>
+          <upper>3.1415926</upper>
         </limit>
       </axis>
       <pose>0 0 0.02 0 0 0</pose>

--- a/models/gimbal_small_1d/model.sdf
+++ b/models/gimbal_small_1d/model.sdf
@@ -140,7 +140,7 @@
       <axis>
         <xyz>1 0 0</xyz>
         <dynamics>
-          <damping>0.5</damping>
+          <damping>0.01</damping>
         </dynamics>
         <limit>
           <lower>-3.1415926</lower>

--- a/models/gimbal_small_2d/model.sdf
+++ b/models/gimbal_small_2d/model.sdf
@@ -79,8 +79,8 @@
           <damping>0.5</damping>
         </dynamics>
         <limit>
-          <lower>-1.57079632</lower>
-          <upper>1.57079632</upper>
+          <lower>-3.1415926</lower>
+          <upper>3.1415926</upper>
         </limit>
       </axis>
       <pose>0.01 0 -0.04 0 0 0</pose>
@@ -179,8 +179,8 @@
           <damping>0.5</damping>
         </dynamics>
         <limit>
-          <lower>-1.57079632</lower>
-          <upper>1.57079632</upper>
+          <lower>-3.1415926</lower>
+          <upper>3.1415926</upper>
         </limit>
       </axis>
       <pose>0 0 0.02 0 0 0</pose>

--- a/models/gimbal_small_2d/model.sdf
+++ b/models/gimbal_small_2d/model.sdf
@@ -76,7 +76,7 @@
       <axis>
         <xyz>0 0 1</xyz>
         <dynamics>
-          <damping>0.5</damping>
+          <damping>0.01</damping>
         </dynamics>
         <limit>
           <lower>-3.1415926</lower>
@@ -176,7 +176,7 @@
       <axis>
         <xyz>1 0 0</xyz>
         <dynamics>
-          <damping>0.5</damping>
+          <damping>0.01</damping>
         </dynamics>
         <limit>
           <lower>-3.1415926</lower>

--- a/models/gimbal_small_3d/model.sdf
+++ b/models/gimbal_small_3d/model.sdf
@@ -74,7 +74,7 @@
       <axis>
         <xyz>0 1 0</xyz>
         <dynamics>
-          <damping>0.5</damping>
+          <damping>0.01</damping>
         </dynamics>
         <limit>
           <lower>-3.1415926</lower>
@@ -122,7 +122,7 @@
       <axis>
         <xyz>0 0 1</xyz>
         <dynamics>
-          <damping>0.5</damping>
+          <damping>0.01</damping>
         </dynamics>
         <limit>
           <lower>-3.1415926</lower>
@@ -227,7 +227,7 @@
       <axis>
         <xyz>1 0 0</xyz>
         <dynamics>
-          <damping>0.5</damping>
+          <damping>0.01</damping>
         </dynamics>
         <limit>
           <lower>-3.1415926</lower>

--- a/models/gimbal_small_3d/model.sdf
+++ b/models/gimbal_small_3d/model.sdf
@@ -77,8 +77,8 @@
           <damping>0.5</damping>
         </dynamics>
         <limit>
-          <lower>-1.57079632</lower>
-          <upper>1.57079632</upper>
+          <lower>-3.1415926</lower>
+          <upper>3.1415926</upper>
         </limit>
       </axis>
       <pose>0.0105 0.065 -0.002 0 0 0</pose>
@@ -125,8 +125,8 @@
           <damping>0.5</damping>
         </dynamics>
         <limit>
-          <lower>-1.57079632</lower>
-          <upper>1.57079632</upper>
+          <lower>-3.1415926</lower>
+          <upper>3.1415926</upper>
         </limit>
       </axis>
       <pose>0.0099 0.002 -0.05 0 0 0</pose>
@@ -230,8 +230,8 @@
           <damping>0.5</damping>
         </dynamics>
         <limit>
-          <lower>-1.57079632</lower>
-          <upper>1.57079632</upper>
+          <lower>-3.1415926</lower>
+          <upper>3.1415926</upper>
         </limit>
       </axis>
       <pose>0.045 0.0021 0.0199 0 0 0</pose>

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -6,7 +6,7 @@
     </include>
 
     <include>
-      <uri>model://gimbal_small_2d</uri>
+      <uri>model://gimbal_small_3d</uri>
       <name>gimbal</name>
       <pose degrees="true">0 -0.01 -0.124923 90 0 90</pose>    
     </include>
@@ -292,13 +292,24 @@
       </control>
 
       <control channel="5">
-        <jointName>gimbal::tilt_joint</jointName>
+        <jointName>gimbal::pitch_joint</jointName>
         <multiplier>3.14159265</multiplier>
         <offset>-0.5</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
         <type>COMMAND</type>
-        <cmd_topic>/gimbal/cmd_tilt</cmd_topic>
+        <cmd_topic>/gimbal/cmd_pitch</cmd_topic>
+        <p_gain>3</p_gain>
+      </control>
+
+      <control channel="6">
+        <jointName>gimbal::yaw_joint</jointName>
+        <multiplier>3.14159265</multiplier>
+        <offset>-0.5</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>COMMAND</type>
+        <cmd_topic>/gimbal/cmd_yaw</cmd_topic>
         <p_gain>3</p_gain>
       </control>
 
@@ -314,8 +325,15 @@
     <plugin
       filename="gz-sim-joint-position-controller-system"
       name="gz::sim::systems::JointPositionController">
-      <joint_name>gimbal::tilt_joint</joint_name>
-      <topic>/gimbal/cmd_tilt</topic>
+      <joint_name>gimbal::pitch_joint</joint_name>
+      <topic>/gimbal/cmd_pitch</topic>
+      <p_gain>2</p_gain>
+    </plugin>
+    <plugin
+      filename="gz-sim-joint-position-controller-system"
+      name="gz::sim::systems::JointPositionController">
+      <joint_name>gimbal::yaw_joint</joint_name>
+      <topic>/gimbal/cmd_yaw</topic>
       <p_gain>2</p_gain>
     </plugin>
 

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -280,7 +280,7 @@
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
-      <control channel="4">
+      <control channel="8">
         <jointName>gimbal::roll_joint</jointName>
         <multiplier>3.14159265</multiplier>
         <offset>-0.5</offset>
@@ -288,29 +288,29 @@
         <servo_max>1900</servo_max>
         <type>COMMAND</type>
         <cmd_topic>/gimbal/cmd_roll</cmd_topic>
-        <p_gain>3</p_gain>
+        <p_gain>2</p_gain>
       </control>
 
-      <control channel="5">
+      <control channel="9">
         <jointName>gimbal::pitch_joint</jointName>
-        <multiplier>3.14159265</multiplier>
+        <multiplier>-3.14159265</multiplier>
         <offset>-0.5</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
         <type>COMMAND</type>
         <cmd_topic>/gimbal/cmd_pitch</cmd_topic>
-        <p_gain>3</p_gain>
+        <p_gain>2</p_gain>
       </control>
 
-      <control channel="6">
+      <control channel="10">
         <jointName>gimbal::yaw_joint</jointName>
-        <multiplier>3.14159265</multiplier>
+        <multiplier>-3.14159265</multiplier>
         <offset>-0.5</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
         <type>COMMAND</type>
         <cmd_topic>/gimbal/cmd_yaw</cmd_topic>
-        <p_gain>3</p_gain>
+        <p_gain>2</p_gain>
       </control>
 
     </plugin>

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -280,9 +280,10 @@
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
+      <!-- roll range is -30 to +30 deg -->
       <control channel="8">
         <jointName>gimbal::roll_joint</jointName>
-        <multiplier>3.14159265</multiplier>
+        <multiplier>1.047197551196</multiplier>
         <offset>-0.5</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
@@ -291,10 +292,11 @@
         <p_gain>2</p_gain>
       </control>
 
+      <!-- pitch range is -135 to +45 deg -->
       <control channel="9">
         <jointName>gimbal::pitch_joint</jointName>
         <multiplier>-3.14159265</multiplier>
-        <offset>-0.5</offset>
+        <offset>-0.75</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
         <type>COMMAND</type>
@@ -302,9 +304,10 @@
         <p_gain>2</p_gain>
       </control>
 
+      <!-- yaw range is -160 to +160 deg -->
       <control channel="10">
         <jointName>gimbal::yaw_joint</jointName>
-        <multiplier>-3.14159265</multiplier>
+        <multiplier>-5.5850536</multiplier>
         <offset>-0.5</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>

--- a/worlds/iris_runway.sdf
+++ b/worlds/iris_runway.sdf
@@ -116,7 +116,7 @@
     </include>
 
     <include>
-      <uri>model://iris_with_ardupilot</uri>
+      <uri>model://iris_with_gimbal</uri>
       <pose degrees="true">0 0 0.195 0 0 90</pose>
     </include>
 

--- a/worlds/iris_warehouse.sdf
+++ b/worlds/iris_warehouse.sdf
@@ -250,7 +250,7 @@
 
     <include>
         <pose>-6 0 0.25 0 0 0</pose>
-        <uri>model://iris_with_ardupilot</uri>
+        <uri>model://iris_with_gimbal</uri>
     </include>
 
     <include>


### PR DESCRIPTION
Updates https://github.com/ArduPilot/ardupilot_gazebo/pull/86 which was on a `main` branch preventing maintainer edits.

- Update the gimbal model used by the Iris to 3d and add yaw control channel.
- Use the `iris_with_gimbal` model as default in example worlds.
- Reduce position controller PID gains to reduce potential oscillation.
- Update channels to match servo gimbal wiki doc: https://ardupilot.org/copter/docs/common-camera-gimbal.html
- Update servo control direction

| Action | Channel | RC Low | RC High |  Min (deg) | Max (deg) |
| --- | --- | --- | --- | --- | --- |
| Roll | RC6 | Roll Left | Roll Right | -30 | +30 |
| Pitch | RC7 | Pitch Dn | Pitch Up | -135 | +45 |
| Yaw | RC8 | Yaw Left | Yaw Right | -160 | 160 |

Copter params

```bash
# Iris is X frame
FRAME_CLASS	     1
FRAME_TYPE	     1

# Match servo out for motors
MOT_PWM_MIN      1100
MOT_PWM_MAX      1900

# Gimbal on mount 1 has 3 DOF
MNT1_TYPE        1           # Servo
MNT1_PITCH_MAX   45
MNT1_PITCH_MIN   -135
MNT1_ROLL_MAX    30
MNT1_ROLL_MIN    -30
MNT1_YAW_MAX     160
MNT1_YAW_MIN     -160

# Gimbal RC in
RC6_MAX          1900
RC6_MIN          1100
RC6_OPTION       212         # Mount1 Roll
RC7_MAX          1900
RC7_MIN          1100
RC7_OPTION       213         # Mount1 Pitch
RC8_MAX          1900
RC8_MIN          1100
RC8_OPTION       214         # Mount1 Yaw
RC8_REVERSED     0           # Normal
RC9_MAX          1900
RC9_MIN          1100
RC9_OPTION       0           # Do Nothing

# Gimbal servo out
SERVO9_FUNCTION  8           # Mount1Roll
SERVO10_FUNCTION 7           # Mount1Pitch
SERVO11_FUNCTION 6           # Mount1Yaw
```

_Figure: gimbal tracking ROI located at the home position while Iris circles_
![iris-gimbal-3d-roi](https://github.com/ArduPilot/ardupilot_gazebo/assets/24916364/465604fb-a8e1-4db9-aaa2-75d6b4274938)

The `GstCameraPlugin` is also enabled by default. To view the video in QGC edit `Application Settings > Video Settings`. Select `UDP h.264 Video Stream` and use the default port `5600`. 

![iris-gimbal-3d-qcg](https://github.com/ArduPilot/ardupilot_gazebo/assets/24916364/3be31d56-460f-4d0a-bc73-e140a92df7fd)

## Testing

Tested on macOS Sonoma 14.5 and Ubuntu 22.04 (VM). Both running ArduPilot `master` with Gazebo Harmonic.

