### PR TITLE
Gimbal: Added rc channel control readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,47 @@ Display the streamed video:
 gst-launch-1.0 -v udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' ! rtph264depay ! avdec_h264 ! videoconvert ! autovideosink sync=false
 ```
 
+View the streamed camera frames in [QGC](http://qgroundcontrol.com/):
+
+`Open QGC > Application Settings > Video Settings > Select UDP h.264 Video Stream & use port 5600`
+
+![qgc_video_settings](https://github.com/user-attachments/assets/61fa4c2a-37e2-47cf-abcf-9f110d9c2015)
+
+
+### 4. Using 3d Gimbal
+
+The Iris model is equipped with a 3d gimbal and camera that can be controlled directly in MAVProxy using the RC overrides.
+
+#### Run Gazebo
+
+```bash
+gz sim -v4 -r iris_runway.sdf
+```
+
+#### Run ArduPilot SITL with a specified parameter file
+
+```bash
+cd ardupilot
+
+sim_vehicle.py -D -v ArduCopter -f JSON --add-param-file=$HOME/ardupilot_gazebo/config/gazebo-iris-gimbal.parm --console --map
+```
+
+Control action for gimbal over RC channel:
+
+| Action | Channel | RC Low | RC High |
+| ------------- | ------------- | ------------- | ------------- |
+| Roll | RC6 | Roll Left | Roll Right |
+| Pitch | RC7 | Pitch Down | Pitch Up |
+| Yaw | RC8 | Yaw Left | Yaw Right |
+
+Example usage:
+
+`rc 6 1100` - Gimbal rolls left
+
+`rc 7 1900` - Gimbal pitch upwards
+
+`rc 8 1500` - Gimbal yaw neutral
+
 ## Models
 
 In addition to the Iris and Zephyr models included here, a selection

--- a/config/gazebo-iris-gimbal.parm
+++ b/config/gazebo-iris-gimbal.parm
@@ -25,10 +25,6 @@ RC7_OPTION       213         # Mount1 Pitch
 RC8_MAX          1900
 RC8_MIN          1100
 RC8_OPTION       214         # Mount1 Yaw
-RC8_REVERSED     0           # Normal
-RC9_MAX          1900
-RC9_MIN          1100
-RC9_OPTION       0           # Do Nothing
 
 # Gimbal servo out
 SERVO9_FUNCTION  8           # Mount1Roll


### PR DESCRIPTION
In reference to the [PR](https://github.com/ArduPilot/ardupilot_gazebo/pull/102) by @srmainwaring. Updated readme to setup and control gimbal over ground control. 