### PR TITLE
Add gz_frame_id's to sensors

### DIFF
--- a/models/gimbal_small_1d/model.sdf
+++ b/models/gimbal_small_1d/model.sdf
@@ -108,6 +108,7 @@
         </geometry>
       </collision>
       <sensor name="camera" type="camera">
+        <gz_frame_id>tilt_link</gz_frame_id>
         <pose degrees="true">0 0 0 -90 -90 0</pose>
         <camera>
           <horizontal_fov>2.0</horizontal_fov>

--- a/models/gimbal_small_2d/model.sdf
+++ b/models/gimbal_small_2d/model.sdf
@@ -144,6 +144,7 @@
         </geometry>
       </collision>
       <sensor name="camera" type="camera">
+        <gz_frame_id>tilt_link</gz_frame_id>
         <pose degrees="true">0 0 0 -90 -90 0</pose>
         <camera>
           <horizontal_fov>2.0</horizontal_fov>

--- a/models/gimbal_small_3d/model.sdf
+++ b/models/gimbal_small_3d/model.sdf
@@ -189,6 +189,7 @@
         </geometry>
       </collision>
       <sensor name="camera" type="camera">
+        <gz_frame_id>pitch_link</gz_frame_id>
         <pose>0 0 0 -1.57 -1.57 0</pose>
         <camera>
           <horizontal_fov>2.0</horizontal_fov>

--- a/models/iris_with_standoffs/model.sdf
+++ b/models/iris_with_standoffs/model.sdf
@@ -178,6 +178,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
+        <gz_frame_id>imu_link</gz_frame_id>
         <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>

--- a/models/zephyr/model.sdf
+++ b/models/zephyr/model.sdf
@@ -260,6 +260,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
+        <gz_frame_id>imu_link</gz_frame_id>
         <pose degrees="true">0 0 0 180 0 -90</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>


### PR DESCRIPTION
Adds `gz_frame_id` to camera and IMU sensor to ensure the ROS topics have the correct `frame_id`.

`gz_frame_id` is also already added in other models used with Ardupilot:
- https://github.com/ArduPilot/ardupilot_gz/pull/64
- https://github.com/ArduPilot/SITL_Models/commit/ed8a3d25b66b5200fe8585f87104cd278da90753#diff-e62fc778fd4fc8dea0507f90838bf11850f7ae06eccd773aad32324a39388252

Tested on Ubuntu 22.04, Gazebo Harmonic and ROS 2 Humble