### PR TITLE
Add motor plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,10 @@ add_library(MotorPlugin
   SHARED
   src/MotorPlugin.cc
   src/Util.cc
+<<<<<<< HEAD
+=======
+
+>>>>>>> dev/motor_plugin
 )
 target_include_directories(MotorPlugin PRIVATE
   include
@@ -146,6 +150,7 @@ target_link_libraries(GstCameraPlugin PRIVATE
 install(
   TARGETS
   ArduPilotPlugin
+  MotorPlugin
   ParachutePlugin
   CameraZoomPlugin
   GstCameraPlugin

--- a/include/MotorPlugin.hh
+++ b/include/MotorPlugin.hh
@@ -26,6 +26,7 @@ namespace sim {
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems {
 
+<<<<<<< HEAD
 /// \brief Parachute releaase plugin which may be attached to a model.
 ///
 /// ## System Parameters:
@@ -45,11 +46,17 @@ namespace systems {
 ///   `<cmd_topic>` The topic to receive  the parachute release command.
 ///   The default value is: `/model/<model_name>/parachute/cmd_release`.
 ///
+=======
+
+>>>>>>> dev/motor_plugin
 class MotorPlugin :
     public System,
     public ISystemConfigureParameters,
     public ISystemPreUpdate,
+<<<<<<< HEAD
     public ISystemPostUpdate,
+=======
+>>>>>>> dev/motor_plugin
     public ISystemConfigure
 {
   /// \brief Destructor
@@ -62,15 +69,22 @@ class MotorPlugin :
   public: void PreUpdate(const gz::sim::UpdateInfo &_info,
                          EntityComponentManager &_ecm) final;
 
+<<<<<<< HEAD
   public: void PostUpdate(const gz::sim::UpdateInfo &_info,
                           const gz::sim::EntityComponentManager &_ecm) final;
 
+=======
+>>>>>>> dev/motor_plugin
   // Documentation inherited
   public: void Configure(const Entity &_entity,
                          const std::shared_ptr<const sdf::Element> &_sdf,
                          EntityComponentManager &_ecm,
                          EventManager &) final;
+<<<<<<< HEAD
 
+=======
+  
+>>>>>>> dev/motor_plugin
   public: void ConfigureParameters(
       gz::transport::parameters::ParametersRegistry &_registry,
       gz::sim::EntityComponentManager &_ecm) override;
@@ -79,7 +93,11 @@ class MotorPlugin :
   private: void LoadControlChannels(
     sdf::ElementPtr _sdf,
     gz::sim::EntityComponentManager &_ecm);
+<<<<<<< HEAD
 
+=======
+    
+>>>>>>> dev/motor_plugin
   /// \internal
   /// \brief Private implementation
   private: class Impl;
@@ -91,4 +109,8 @@ class MotorPlugin :
 }  // namespace sim
 }  // namespace gz
 
+<<<<<<< HEAD
 #endif  // PARACHUTEPLUGIN_HH_
+=======
+#endif  // MOTORPLUGIN_HH_
+>>>>>>> dev/motor_plugin

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -215,7 +215,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -223,7 +223,11 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+<<<<<<< HEAD
         <!-- <cmd_topic>joint_0</cmd_topic> -->
+=======
+        <cmd_topic>joint_0</cmd_topic>
+>>>>>>> dev/motor_plugin
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -234,7 +238,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -242,7 +246,11 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+<<<<<<< HEAD
         <!-- <cmd_topic>joint_1</cmd_topic> -->
+=======
+        <cmd_topic>joint_1</cmd_topic>
+>>>>>>> dev/motor_plugin
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -253,7 +261,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -261,7 +269,11 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+<<<<<<< HEAD
         <!-- <cmd_topic>joint_2</cmd_topic> -->
+=======
+        <cmd_topic>joint_2</cmd_topic>
+>>>>>>> dev/motor_plugin
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -272,7 +284,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -280,7 +292,11 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+<<<<<<< HEAD
         <!-- <cmd_topic>joint_3</cmd_topic> -->
+=======
+        <cmd_topic>joint_3</cmd_topic>
+>>>>>>> dev/motor_plugin
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -322,6 +338,7 @@
 
     </plugin>
 
+<<<<<<< HEAD
 <!-- //////////////////////////////////////////////// In progress-->
     <!-- <plugin filename="MotorPlugin" name="MotorPlugin">
 
@@ -362,6 +379,82 @@
         </control>
       </plugin> -->
 <!-- //////////////////////////////////////////////// -->
+=======
+    <plugin filename="MotorPlugin" name="MotorPlugin">
+
+        <control channel="0">
+          <joint_name>iris_with_standoffs::rotor_0_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_0</cmd_topic>
+          <multiplier>838</multiplier>
+          <offset>0</offset>
+          <p_gain>0.02</p_gain>
+          <i_gain>0</i_gain>
+          <d_gain>0</d_gain>
+          <i_max>0</i_max>
+          <i_min>0</i_min>
+          <cmd_max>0.18</cmd_max>
+          <cmd_min>-0.18</cmd_min>
+        </control>
+
+        <control channel="1">
+          <joint_name>iris_with_standoffs::rotor_1_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_1</cmd_topic>
+          <multiplier>838</multiplier>
+          <offset>0</offset>
+          <p_gain>0.02</p_gain>
+          <i_gain>0</i_gain>
+          <d_gain>0</d_gain>
+          <i_max>0</i_max>
+          <i_min>0</i_min>
+          <cmd_max>0.18</cmd_max>
+          <cmd_min>-0.18</cmd_min>
+        </control>
+
+        <control channel="2">
+          <joint_name>iris_with_standoffs::rotor_2_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_2</cmd_topic>
+          <multiplier>-838</multiplier>
+          <offset>0</offset>
+          <p_gain>0.02</p_gain>
+          <i_gain>0</i_gain>
+          <d_gain>0</d_gain>
+          <i_max>0</i_max>
+          <i_min>0</i_min>
+          <cmd_max>0.18</cmd_max>
+          <cmd_min>-0.18</cmd_min>
+        </control>
+
+        <control channel="3">
+          <joint_name>iris_with_standoffs::rotor_3_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_3</cmd_topic>
+          <multiplier>-838</multiplier>
+          <offset>0</offset>
+          <p_gain>0.02</p_gain>
+          <i_gain>0</i_gain>
+          <d_gain>0</d_gain>
+          <i_max>0</i_max>
+          <i_min>0</i_min>
+          <cmd_max>0.18</cmd_max>
+          <cmd_min>-0.18</cmd_min>
+        </control>
+      </plugin>
+>>>>>>> dev/motor_plugin
 
     <plugin
       filename="gz-sim-joint-position-controller-system"

--- a/models/iris_with_standoffs/model.sdf
+++ b/models/iris_with_standoffs/model.sdf
@@ -241,7 +241,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>
@@ -315,7 +315,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>
@@ -389,7 +389,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>
@@ -463,7 +463,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>

--- a/scripts/gz_ros_subs.py
+++ b/scripts/gz_ros_subs.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python3
+import rclpy
+from rclpy.node import Node as node
+from std_msgs.msg import Float64
+
+from gz.msgs10.double_pb2 import Double
+from gz.transport13 import Node as GzNode
+import time
+import threading
+
+
+class GzROS2Bridge(node):
+    def __init__(self):
+        super().__init__('gz_ros2_bridge')
+        
+        self.current_publisher = self.create_publisher(
+            Float64, 
+            '/iris_rotor_0_current', 
+            10
+        )
+
+        self.voltage_publisher = self.create_publisher(
+            Float64, 
+            '/iris_rotor_0_voltage', 
+            10
+        )
+        
+        self.gz_node = GzNode()
+        self.gz_current_topic = "/iris_with_standoffs::rotor_0_joint/current"
+        self.gz_voltage_topic = "/iris_with_standoffs::rotor_0_joint/voltage"
+
+        
+        if self.gz_node.subscribe(Double, self.gz_current_topic, self.current_callback):
+            self.get_logger().info(f"Subscribing to current topic: {self.gz_current_topic}")
+        else:
+            self.get_logger().error(f"Failed to subscribe to voltage topic: {self.gz_current_topic}")
+
+        if self.gz_node.subscribe(Double, self.gz_voltage_topic, self.voltage_callback):
+            self.get_logger().info(f"Subscribing to voltage topic: {self.gz_voltage_topic}")
+        else:
+            self.get_logger().error(f"Failed to subscribe to voltage topic: {self.gz_voltage_topic}")
+    
+    def current_callback(self, msg: Double):
+        current_msg = Float64()
+        current_msg.data = msg.data
+        
+        self.current_publisher.publish(current_msg)
+        
+        self.get_logger().info(f"Bridged current data: {msg.data}")
+
+    def voltage_callback(self, msg: Double):
+        current_msg = Float64()
+        current_msg.data = msg.data
+        
+        # Publish to ROS2
+        self.voltage_publisher.publish(current_msg)
+        
+        # Log the data (optional)
+        self.get_logger().info(f"Bridged voltage data: {msg.data}")
+
+
+def main():
+    rclpy.init()
+    
+    bridge = GzROS2Bridge()
+    
+    spin_thread = threading.Thread(target=lambda: rclpy.spin(bridge), daemon=True)
+    spin_thread.start()
+    
+    try:
+        while rclpy.ok():
+            time.sleep(0.001)
+    except KeyboardInterrupt:
+        bridge.get_logger().info("Shutting down bridge...")
+    
+    # Cleanup
+    bridge.destroy_node()
+    rclpy.shutdown()
+    print("Bridge shutdown complete")
+
+if __name__ == "__main__":
+    main()

--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -1237,7 +1237,7 @@ void gz::sim::systems::ArduPilotPlugin::PostUpdate(
                 _info.simTime).count();
         this->CreateStateJSON(t, _ecm);
         this->SendState();
-        this->dataPtr->lastControllerUpdateTime = _info.simTime;
+        // this->dataPtr->lastControllerUpdateTime = _info.simTime;
     }
 }
 
@@ -1642,8 +1642,12 @@ void gz::sim::systems::ArduPilotPlugin::UpdateMotorCommands(
                 // bound incoming cmd between 0 and 1
                 double raw_cmd = (pwm - pwm_min)/(pwm_max - pwm_min);
                 raw_cmd = gz::math::clamp(raw_cmd, 0.0, 1.0);
+
+                // gzdbg << "Raw Cmd:- " << raw_cmd << "\n";
+
                 this->dataPtr->controls[i].cmd =
                     multiplier * (raw_cmd + offset);
+                // gzdbg << "With offset & mult:- " << this->dataPtr->controls[i].cmd << "\n";
 
 #if 0
                 gzdbg << "apply input chan["


### PR DESCRIPTION
### Description
 - This PR introduces an initial motor plugin to enhance motor control and model a motor.
 - The plugin would receive respective commands and converts them into torque which is then fed to the gazebo joint. 
 - Currently it receives parameterised desired velocity values and goes through a PID loop to get target velocity values. 
 
## Checklist
- [x] subscribes to command topic
- [x] functioning motor model
- [x] supports motor stats (e.g. Kv, no-load current etc.)
- [x] supports dynamic PID's
- [x] calculates consumed current
- [x] calculates terminal voltage
- [x] calculates back emf
- [x] publish topic for current consumed

## How to run?

Build
- Clone this branch.
- Change directory to `ardupilot_gazebo` folder.
- `mkdir build && cd build`
- `cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo`
-  `make -j4`

Run
- `gz sim -v4 -r iris_runway.sdf` in one terminal
- `sim_vehicle.py -v ArduCopter -f gazebo-iris --model JSON --map --console` in another terminal. 

To View the output current of the motor
- go to `scripts` folder.
- `python3 gz_ros_subs.py`

This script subscribes to gz topic and converts to ROS2 topic which can then be viewed in PlotJuggler.