### PR TITLE
added motor-plugin and DroneCAN ESC telemetry script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ if("$ENV{GZ_VERSION}" STREQUAL "harmonic" OR NOT DEFINED "ENV{GZ_VERSION}")
   gz_find_package(gz-sim8 REQUIRED)
   set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 
+  gz_find_package(gz-msgs10 REQUIRED)
+  set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
+
   message(STATUS "Compiling against Gazebo Harmonic")
 elseif("$ENV{GZ_VERSION}" STREQUAL "ionic")
   # Ionic
@@ -69,10 +72,29 @@ endif()
 # --------------------------------------------------------------------------- #
 find_package(RapidJSON REQUIRED)
 find_package(OpenCV REQUIRED)
+find_package(Protobuf REQUIRED)
 
 pkg_check_modules(GST REQUIRED gstreamer-1.0 gstreamer-app-1.0)
 
+# --------------------------------------------------------------------------- #
+# Build proto custom messages
+set(ARDUPILOT_MSGS_PROTOS
+   ${CMAKE_CURRENT_SOURCE_DIR}/proto/ardupilot_gazebo/msgs/motor_stats.proto
+)
 
+gz_msgs_generate_messages(
+  # The cmake target to be generated for libraries/executables to link
+  TARGET msgs
+  # The protobuf package to generate (Typically based on the path)
+  PROTO_PACKAGE "ardupilot_gazebo.msgs"
+  # The path to the base directory of the proto files
+  # All import paths should be relative to this (eg gz/custom_msgs/vector3d.proto)
+  MSGS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/proto
+  # List of proto files to generate
+  MSGS_PROTOS ${ARDUPILOT_MSGS_PROTOS}
+  # List of message targets this library imports from
+  DEPENDENCIES gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER}
+)
 # --------------------------------------------------------------------------- #
 # Build plugin.
 
@@ -88,6 +110,24 @@ target_include_directories(ArduPilotPlugin PRIVATE
 target_link_libraries(ArduPilotPlugin PRIVATE
   gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
 )
+
+add_library(MotorPlugin
+  SHARED
+  src/MotorPlugin.cc
+  src/Util.cc
+
+)
+target_include_directories(MotorPlugin PRIVATE
+  include
+  # ${CMAKE_CURRENT_BINARY_DIR}/ardupilot_gazebo-msgs_genmsg
+)
+target_link_libraries(MotorPlugin PRIVATE
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+  ${PROJECT_NAME}-msgs
+  # gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER}
+  # ardupilot_gazebo-msgs
+)
+# add_dependencies(MotorPlugin ardupilot_gazebo-msgs)
 
 add_library(ParachutePlugin
   SHARED
@@ -134,6 +174,7 @@ target_link_libraries(GstCameraPlugin PRIVATE
 install(
   TARGETS
   ArduPilotPlugin
+  MotorPlugin
   ParachutePlugin
   CameraZoomPlugin
   GstCameraPlugin

--- a/include/MotorPlugin.hh
+++ b/include/MotorPlugin.hh
@@ -1,0 +1,67 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef MOTORPLUGIN_HH_
+#define MOTORPLUGIN_HH_
+
+#include <memory>
+
+#include <gz/sim/System.hh>
+
+namespace gz {
+namespace sim {
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace systems {
+
+
+class MotorPlugin :
+    public System,
+    public ISystemPreUpdate,
+    public ISystemConfigure
+{
+	/// \brief Destructor
+	public: virtual ~MotorPlugin();
+
+	/// \brief Constructor
+	public: MotorPlugin();
+
+	// Documentation inherited
+	public: void PreUpdate(const gz::sim::UpdateInfo &_info,
+							EntityComponentManager &_ecm) final;
+
+	// Documentation inherited
+	public: void Configure(const Entity &_entity,
+							const std::shared_ptr<const sdf::Element> &_sdf,
+							EntityComponentManager &_ecm,
+							EventManager &) final;
+
+	/// \brief Load control channels
+	private: void LoadControlChannels(
+		sdf::ElementPtr _sdf,
+		gz::sim::EntityComponentManager &_ecm);
+		
+	/// \internal
+	/// \brief Private implementation
+	private: class Impl;
+	private: std::unique_ptr<Impl> impl;
+};
+
+}  // namespace systems
+}
+}  // namespace sim
+}  // namespace gz
+
+#endif  // MOTORPLUGIN_HH_

--- a/models/iris_with_gimbal/model.sdf
+++ b/models/iris_with_gimbal/model.sdf
@@ -215,7 +215,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -223,6 +223,7 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+        <cmd_topic>joint_0</cmd_topic>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -233,7 +234,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -241,6 +242,7 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+        <cmd_topic>joint_1</cmd_topic>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -251,7 +253,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -259,6 +261,7 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+        <cmd_topic>joint_2</cmd_topic>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -269,7 +272,7 @@
         <offset>0</offset>
         <servo_min>1100</servo_min>
         <servo_max>1900</servo_max>
-        <type>VELOCITY</type>
+        <type>COMMAND</type>
         <p_gain>0.20</p_gain>
         <i_gain>0</i_gain>
         <d_gain>0</d_gain>
@@ -277,6 +280,7 @@
         <i_min>0</i_min>
         <cmd_max>2.5</cmd_max>
         <cmd_min>-2.5</cmd_min>
+        <cmd_topic>joint_3</cmd_topic>
         <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
       </control>
 
@@ -317,6 +321,65 @@
       </control>
 
     </plugin>
+
+    <plugin filename="MotorPlugin" name="MotorPlugin">
+
+        <control channel="0">
+          <joint_name>iris_with_standoffs::rotor_0_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_0</cmd_topic>
+          <multiplier>838</multiplier>
+          <offset>0</offset>
+          <thermal_resistance>1.4</thermal_resistance>
+          <thermal_capacitance>214.28</thermal_capacitance>
+          <ambient_temperature>25.0</ambient_temperature>
+        </control>
+
+        <control channel="1">
+          <joint_name>iris_with_standoffs::rotor_1_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_1</cmd_topic>
+          <multiplier>838</multiplier>
+          <offset>0</offset>
+          <thermal_resistance>1.4</thermal_resistance>
+          <thermal_capacitance>214.28</thermal_capacitance>
+          <ambient_temperature>25.0</ambient_temperature>
+        </control>
+
+        <control channel="2">
+          <joint_name>iris_with_standoffs::rotor_2_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_2</cmd_topic>
+          <multiplier>-838</multiplier>
+          <offset>0</offset>
+          <thermal_resistance>1.4</thermal_resistance>
+          <thermal_capacitance>214.28</thermal_capacitance>
+          <ambient_temperature>25.0</ambient_temperature>
+        </control>
+
+        <control channel="3">
+          <joint_name>iris_with_standoffs::rotor_3_joint</joint_name>
+          <voltage_bat>16</voltage_bat>
+          <speed_constant>920</speed_constant>
+          <resistance>0.115</resistance>
+          <no_load_current>0.8</no_load_current>
+          <cmd_topic>joint_3</cmd_topic>
+          <multiplier>-838</multiplier>
+          <offset>0</offset>
+          <thermal_resistance>1.4</thermal_resistance>
+          <thermal_capacitance>214.28</thermal_capacitance>
+          <ambient_temperature>25.0</ambient_temperature>
+        </control>
+      </plugin>
 
     <plugin
       filename="gz-sim-joint-position-controller-system"

--- a/models/iris_with_standoffs/model.sdf
+++ b/models/iris_with_standoffs/model.sdf
@@ -241,7 +241,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>
@@ -315,7 +315,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>
@@ -389,7 +389,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>
@@ -463,7 +463,7 @@
           <upper>1e+16</upper>
         </limit>
         <dynamics>
-          <damping>0.004</damping>
+          <damping>1.0e-4</damping>
         </dynamics>
       </axis>
       <physics>

--- a/proto/ardupilot_gazebo/msgs/motor_stats.proto
+++ b/proto/ardupilot_gazebo/msgs/motor_stats.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package ardupilot_gazebo.msgs;
+
+// Message to hold the status of a single motor.
+message MotorStats {
+  // Motor Id
+  int32 motor_id = 1;
+
+  // Rotational speed of the motor in revolutions per minute (RPM).
+  double rpm = 2;
+
+  // Voltage supplied to the motor in Volts.
+  double voltage = 3;
+
+  // Current drawn by the motor in Amperes.
+  double current = 4;
+
+  // Motor Temperature in Celsius.
+  double temperature = 5;
+}

--- a/scripts/motor_stats.py
+++ b/scripts/motor_stats.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+# To run this script set PYTHONPATH environment variable to register custom motor_stats message. 
+# Run this in main directory:- export PYTHONPATH=$PYTHONPATH:`pwd`/build/ardupilot_gazebo-msgs_genmsg/python/
+
+# Basic setup for dronecan:-
+# sudo modprobe vcan
+# sudo ip link add dev vcan0 type vcan
+# sudo ip link set up vcan0
+# To check:- ip link show vcan0
+
+
+import time
+import argparse
+import threading
+import dronecan
+from gz.transport13 import Node
+
+
+try:
+    from ardupilot_gazebo.msgs.motor_stats_pb2 import MotorStats
+except ImportError:
+    print("Error: Could not import the MotorStats protobuf message.")
+    print("Please ensure you have compiled MotorStats.proto and the resulting")
+    print("Python module is in your PYTHONPATH.")
+    exit(1)
+
+class MotorStatsSubscriber:
+    def __init__(self, node_id, dronecan_port, model_name, joint_name):
+        self._model_name = model_name
+        self._joint_name = joint_name
+        self._node_id = node_id
+        self._dronecan_port = dronecan_port
+        self._lock = threading.Lock()
+        self._node = Node()
+        self._dronecan_node = None
+        self._initialized = False
+        
+
+        print(f"Initializing DroneCAN node {node_id} on '{dronecan_port}'...")
+        try:
+            self._dronecan_node = dronecan.make_node(dronecan_port, node_id=node_id, bitrate=1000000)
+        except Exception as e:
+            print(f"Error initializing DroneCAN node: {e}")
+            print("Please ensure the CAN interface exists and is configured correctly.")
+            return
+
+
+        self._topic = f"/model/{self._model_name}/joint/{self._joint_name}/motor_stats"
+        if self._node.subscribe(MotorStats, self._topic, self.motor_stats_cb):
+            print("Subscribing to type {} on topic [{}]".format(MotorStats, self._topic))
+            self._initialized = True 
+        else:
+            print("Error subscribing to topic [{}]".format(self._topic))
+            return
+
+    def motor_stats_cb(self, msg: MotorStats):
+        if not self._initialized or self._dronecan_node is None:
+            return
+            
+        try:
+            with self._lock:
+                dronecan_msg = dronecan.uavcan.equipment.esc.Status()
+                dronecan_msg.esc_index = int(msg.motor_id)
+                dronecan_msg.rpm = int(msg.rpm)
+                dronecan_msg.voltage = float(msg.voltage)
+                dronecan_msg.current = float(msg.current)
+                dronecan_msg.temperature = float(msg.temperature)
+                
+                self._dronecan_node.broadcast(dronecan_msg)
+        except Exception as e:
+            print(f"Error broadcasting DroneCAN message: {e}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Gazebo to DroneCAN ESC bridge.")
+    parser.add_argument('dronecan_port', type=str, help="CAN interface name (e.g., vcan0, slcan:/dev/ttyACM0).")
+    parser.add_argument('--node-id', type=int, default=100, help="DroneCAN node ID for this bridge.")
+    parser.add_argument('--model-name', type=str, default="iris_with_gimbal", help="Name of the model in Gazebo.")
+    parser.add_argument('--num-motors', type=int, default=4, help="Number of motors on the model.")
+    args = parser.parse_args()
+
+    print(f"Number of motors: {args.num_motors}")
+    
+    for i in range(args.num_motors):
+        joint_name = f"iris_with_standoffs::rotor_{i}_joint"
+        MotorStatsSubscriber(args.node_id, args.dronecan_port, args.model_name, joint_name)
+    try:
+        while True:
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+
+if __name__ == '__main__':
+    main()

--- a/src/MotorPlugin.cc
+++ b/src/MotorPlugin.cc
@@ -1,0 +1,548 @@
+/*
+   Copyright (C) 2025 ArduPilot.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "MotorPlugin.hh"
+
+#include <gz/msgs/entity_factory.pb.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gz/plugin/Register.hh>
+#include <gz/common/Profiler.hh>
+#include <gz/sim/components/Joint.hh>
+#include <gz/sim/components/JointVelocity.hh>
+#include <gz/sim/components/JointForceCmd.hh>
+#include <gz/sim/components/Link.hh>
+#include <gz/sim/components/Model.hh>
+#include <gz/sim/components/Name.hh>
+#include <gz/sim/components/ParentEntity.hh>
+#include <gz/sim/components/World.hh>
+#include <gz/sim/Joint.hh>
+#include <gz/sim/Link.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/World.hh>
+#include <gz/sim/Util.hh>
+#include <gz/math/Filter.hh>
+#include <gz/transport/Node.hh>
+#include <gz/transport/parameters.hh>
+#include <gz/msgs/double.pb.h>
+#include <ardupilot_gazebo/msgs/motor_stats.pb.h> 
+#include <string>
+#include "Util.hh"
+
+
+namespace gz {
+namespace sim {
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace systems {
+
+/// \brief class Control is responsible for controlling a joint
+class Control
+{
+	/// \brief Constructor
+	public: Control() {}
+
+	/// \brief Desctuctor  
+	public: ~Control() {}
+
+	/// \brief The PWM channel used to command this control
+	public: int channel = 0;
+
+	/// \brief name of the joint being controlled
+	public: std::string jointName;
+
+	/// \brief battery voltage
+	public: double voltageBat;
+
+	/// \brief speed constant of motor (Kv)
+	public: double speedConstant;
+
+	/// \brief motor internal resistance  
+	public: double internal_resistance;
+
+    /// \brief dynamic motor resistance while working
+    public: double resistance;
+
+	/// \brief no load current of motor 
+	public: double noLoadCurrent;
+
+	/// \brief A multiplier to scale the raw input command
+	public: double multiplier;
+
+	/// \brief An offset to shift the zero-point of the raw input command
+	public: double offset;
+
+	/// \brief thermal resistance of the motor
+	public: double thermal_resistance;
+
+	/// \brief thermal capacitance of the motor
+	public: double thermal_capacitance;
+
+	/// \brief ambient working temperature 
+	public: double ambient_temperature;
+
+	/// \brief Motor temperature 
+	public: double temperature;
+
+	/// \brief joint being controlled
+	public: gz::sim::Entity joint;
+
+	/// \brief Publisher for motor stats
+	public: gz::transport::Node::Publisher motorStatsPub;
+};
+
+//////////////////////////////////////////////////
+class MotorPlugin::Impl
+{ 
+	/// \brief Callback for subscription for Velocity msg .
+	///
+	/// \param controlIndex -> Index of the message 
+	/// \param _msg -> message itself.
+  	/// The command message is a target Velocity.
+	public: void OnVelMsg(int controlIndex, const gz::msgs::Double &_msg);
+
+	/// \brief World occupied by the parent model.
+	public: World world{kNullEntity};
+	
+	/// \brief Name of the world entity.
+	public: std::string worldName;
+
+	/// \brief Model entity of Motor Model.
+	public: Model parentModel{kNullEntity};
+
+	/// \brief Name of the model entity.
+	public: std::string parentModelName;
+
+	/// \brief Array of controllers
+	public: std::vector<Control> controls;
+
+	/// \brief Array of msg command topics.
+	public: std::vector<std::string> topics;
+
+	/// \brief Stores target velocity values.
+	public: std::vector<double> velValues;
+	
+	/// \brief Mutex to protect velValues
+	public: std::mutex velMutex;
+
+	/// \brief Check to see if the config is valid  
+	public: bool validConfig{false};
+
+	/// \brief gz-transport Node to subscribe to velValues data coming from ArduPilotPlugin
+	gz::transport::Node node;
+
+	/// \brief Joint Entity
+	public: Joint joint{kNullEntity};
+};
+
+//////////////////////////////////////////////////
+void MotorPlugin::Impl::OnVelMsg(int controlIndex, const gz::msgs::Double &_msg)
+{
+	std::lock_guard<std::mutex> lock(this->velMutex);
+
+	// Bounds checking
+	if (controlIndex >= 0 && controlIndex < static_cast<int>(this->velValues.size()))
+	{
+		this->velValues[controlIndex] = _msg.data();
+	}
+	else
+	{
+		gzwarn << "Invalid control index " << controlIndex << " for PWM message. Expected [0, " 
+			<< (this->velValues.size() - 1) << "]" << std::endl;
+	}
+}
+
+
+//////////////////////////////////////////////////
+MotorPlugin::~MotorPlugin() = default;
+
+//////////////////////////////////////////////////
+MotorPlugin::MotorPlugin() : impl(std::make_unique<MotorPlugin::Impl>())
+{
+}
+
+//////////////////////////////////////////////////
+void MotorPlugin::Configure(
+    const Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    EntityComponentManager &_ecm,
+    EventManager &)
+{
+
+    // Make a clone so that we can call non-const methods
+    sdf::ElementPtr sdfClone = _sdf->Clone();
+
+    // retrieve world entity
+    this->impl->world = World(
+        _ecm.EntityByComponents(components::World()));
+    if (!this->impl->world.Valid(_ecm))
+    {
+        gzerr << "MotorPlugin - world not found. "
+                "Failed to initialize.\n";
+        return;
+    }
+    this->impl->worldName = this->impl->world.Name(_ecm).value();
+    
+    // capture model entity
+    this->impl->parentModel = Model(_entity);
+    if (!this->impl->parentModel.Valid(_ecm))
+    {
+        gzerr << "MotorPlugin should be attached to a model. "
+                "Failed to initialize.\n";
+        return;
+    }
+    this->impl->parentModelName = this->impl->parentModel.Name(_ecm);
+
+    // Load control channel params
+    this->LoadControlChannels(sdfClone, _ecm);
+
+    // Initialize msg values vector for safety
+    this->impl->velValues.resize(this->impl->controls.size(), 0.0);
+
+    // create components and subscriptions.
+    for (int i = 0; i < this->impl->controls.size(); ++i)
+    {
+        auto &control = this->impl->controls[i];
+        
+        // Create joint components
+        if (!_ecm.Component<gz::sim::components::JointVelocity>(control.joint))
+        {
+            _ecm.CreateComponent(control.joint, gz::sim::components::JointVelocity({0.0}));
+        }
+        if (!_ecm.Component<gz::sim::components::JointForceCmd>(control.joint))
+        {
+            _ecm.CreateComponent(control.joint, gz::sim::components::JointForceCmd({0.0}));
+        }
+
+        // Subscriber
+        std::string topic = this->impl->topics[i];
+        this->impl->node.Subscribe<gz::msgs::Double>(
+            topic,
+            [this, i](const gz::msgs::Double &_msg, const gz::transport::MessageInfo &_info) {
+                this->impl->OnVelMsg(i, _msg);
+            });
+
+        gzdbg << "MotorPlugin subscribing to PWM messages on [" << topic 
+            << "] for control index " << i << std::endl;
+    }
+    this->impl->validConfig = true;
+
+}
+
+/////////////////////////////////////////////////
+void MotorPlugin::LoadControlChannels(
+    sdf::ElementPtr _sdf,
+    gz::sim::EntityComponentManager &_ecm)
+{
+    // per control channel 
+    sdf::ElementPtr controlSdf;
+    if (_sdf->HasElement("control"))
+    {
+        controlSdf = _sdf->GetElement("control");
+    }
+    while (controlSdf)
+    {
+        Control control;
+
+        if (controlSdf->HasAttribute("channel"))
+        {
+            control.channel = atoi(controlSdf->GetAttribute("channel")->GetAsString().c_str());
+        }
+        else
+        {
+        gzwarn << "[" << this->impl->parentModelName << "] "
+                <<  "id/channel attribute not specified, use order parsed ["
+                << control.channel << "].\n";
+        }
+
+        // parameters
+        if (controlSdf->HasElement("joint_name"))
+        {
+            control.jointName = controlSdf->Get<std::string>("joint_name");
+        }
+        else
+        {
+            gzerr << "[" << this->impl->parentModelName << "] "
+                    << "Please specify a joint_name,"
+                    << " where the control channel is attached.\n";
+        }
+
+        // Get the pointer to the joint.
+        control.joint = JointByName(_ecm, this->impl->parentModel.Entity(), control.jointName);
+        if (control.joint == gz::sim::kNullEntity)
+        {
+            gzerr << "Joint [" << control.joint << "] not found in model [" << this->impl->parentModel.Name(_ecm) << "]" << "\n";
+            return;
+        }
+        else
+        {
+            gzmsg << "Got Joint [" << control.joint << "]\n";  
+        }
+
+        if (controlSdf->HasElement("voltage_bat"))
+        {
+            control.voltageBat = controlSdf->Get<double>("voltage_bat");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'voltage_bat'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+    
+        if (controlSdf->HasElement("speed_constant"))
+        {
+            control.speedConstant = controlSdf->Get<double>("speed_constant");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'speed_constant'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+    
+        if (controlSdf->HasElement("resistance"))
+        {
+        control.internal_resistance = controlSdf->Get<double>("resistance");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'resistance'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+    
+        if (controlSdf->HasElement("no_load_current"))
+        {
+            control.noLoadCurrent = controlSdf->Get<double>("no_load_current");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'no_load_current'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+
+        if (controlSdf->HasElement("cmd_topic"))
+        {
+            this->impl->topics.push_back (controlSdf->Get<std::string>("cmd_topic"));
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'cmd_topic'. "
+                    "Failed to initialize.\n";
+            return;
+        }    
+        
+        if (controlSdf->HasElement("multiplier"))
+        {
+            control.multiplier = controlSdf->Get<double>("multiplier");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'multiplier'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+
+        if (controlSdf->HasElement("offset"))
+        {
+            control.offset = controlSdf->Get<double>("offset");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'offset'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+
+        if (controlSdf->HasElement("thermal_resistance"))
+        {
+            control.thermal_resistance = controlSdf->Get<double>("thermal_resistance");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'thermal_resistance'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+
+        if (controlSdf->HasElement("thermal_capacitance"))
+        {
+            control.thermal_capacitance = controlSdf->Get<double>("thermal_capacitance");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'thermal_capacitance'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+
+        if (controlSdf->HasElement("ambient_temperature"))
+        {
+            control.ambient_temperature = controlSdf->Get<double>("ambient_temperature");
+        }
+        else
+        {
+            gzerr << "MotorPlugin requires parameter 'ambient_temperature'. "
+                    "Failed to initialize.\n";
+            return;
+        }
+
+        std::string motorStatsTopic = "/model/" + this->impl->parentModelName + "/joint/" + control.jointName + "/motor_stats";
+        control.motorStatsPub = this->impl->node.Advertise<ardupilot_gazebo::msgs::MotorStats>(motorStatsTopic);
+
+        this->impl->controls.push_back(control);
+        controlSdf = controlSdf->GetNextElement("control");
+    }
+}
+
+
+//////////////////////////////////////////////////
+void MotorPlugin::PreUpdate(
+    const gz::sim::UpdateInfo &_info,
+    EntityComponentManager &_ecm)
+{
+    GZ_PROFILE("MotorPlugin::PreUpdate");
+    double voltage=0.0;
+    double current=0.0;
+    
+    // gzdbg << "This is Dt:- " << dt << "\n";
+    for (size_t i = 0; i < this->impl->controls.size(); ++i)
+    {
+        auto &control = this->impl->controls[i];
+        double targetSpeed = 0.0;
+        
+        auto joint_vel_comp = _ecm.Component<gz::sim::components::JointVelocity>(control.joint);
+        if (!joint_vel_comp)
+        {
+            gzerr << "JointVelocity component missing for joint [" << control.jointName << "]\n";
+            return;
+        }
+
+        const auto &velocities = joint_vel_comp->Data();
+        if (velocities.empty())
+        {
+            gzwarn << "Empty velocities for joint [" << control.jointName << "]\n";
+            continue;
+        }
+
+        // current joint speed (rad/s)
+        double currSpeed = velocities[0];
+        {
+            std::lock_guard<std::mutex> lock(this->impl->velMutex);
+            targetSpeed = this->impl->velValues[i];
+        }
+
+        double kv = (control.speedConstant * (2.0 * M_PI)) / 60.0;
+        double pwm = (targetSpeed / control.multiplier) - control.offset;
+        
+        if (targetSpeed < 0)
+        {
+            pwm = -pwm;
+        }
+        voltage = control.voltageBat * pwm;
+    
+        double backEmfV = currSpeed / kv ;  // Ω/KV
+        
+        // R_T = R_0 * (1 + a(T - T_0))
+        // a -> alpha (temperature coefficient for copper is 0.00393)
+        // T_0 -> reference temperature taken as ambient temperature for simplicity
+        control.resistance = control.internal_resistance * (1.0 + 0.00393 * (control.temperature - control.ambient_temperature));
+        current = (voltage - backEmfV) / control.resistance;
+      
+        double torque = 0.0;
+        if (std::abs(current) > control.noLoadCurrent)
+        {
+            torque = (current - (current > 0 ? 1 : -1) * control.noLoadCurrent) / kv;
+        }
+        
+        // Temperature calculation
+        // Parameter calcultion
+            // P_loss = P_resistive + P_friction
+            // P_resistance = I^2 * R = 16.37^2 * 0.115;
+            // P_friction = i_0 * v_m; (no load current and backemf)
+            // so P_loss = 39.38W (at full throttle)
+
+            // R_th = (T - T_amb)/P_loss = (80 - 25)/39.38 = 1.40 deg C
+            // C_th = t/R_th = 300/1.40 = 214.28 (t -> tau (thermal time constant), estimated from datasheet)
+        // temperature eqns
+            // dT/dt = P_loss/C_th - (T - T_amb)/(R_th*C_th)
+            // C_th -> thermal capacitance, r_th -> therma resistance
+            // T -> current motor temperature
+            // T_amb -> ambient temperature
+        
+        double p_resistive = std::pow(std::abs(current), 2) * control.resistance;
+        double p_friction = control.noLoadCurrent * std::abs(backEmfV);
+        double p_loss = p_resistive + p_friction;
+        double dt = std::chrono::duration<double>(_info.dt).count();
+        double dT_dt = (p_loss / control.thermal_capacitance) - ((control.temperature - control.ambient_temperature) / (control.thermal_resistance * control.thermal_capacitance));
+        control.temperature += dT_dt * dt;
+        if (control.temperature < control.ambient_temperature) {
+            control.temperature = control.ambient_temperature;
+        }
+
+        currSpeed = (currSpeed * 60.0) / (2.0 * M_PI); // rad/s -> rpm
+
+        // Publish motor stats
+        ardupilot_gazebo::msgs::MotorStats motorStatsMsg;
+        motorStatsMsg.set_motor_id(control.channel);
+        motorStatsMsg.set_rpm(currSpeed);
+        motorStatsMsg.set_voltage(voltage);
+        motorStatsMsg.set_current(current);
+		motorStatsMsg.set_temperature(control.temperature);
+        if (!control.motorStatsPub.Publish(motorStatsMsg))
+        {
+            gzerr << "Failed to publish motor stats for joint [" << control.jointName << "]\n";
+        }
+
+	    // debugging
+        // gzdbg << "Index:- " << i << " TargetS:- " << targetSpeed << " Curr Speed:- " << currSpeed << " Pwm:- "<< pwm << " Torque:- " << torque << " Voltage:- " << voltage << " Current:- " << current << " Temperature:- " << control.temperature << "\n";
+
+        // Apply torque to joint
+        auto jfcComp = _ecm.Component<gz::sim::components::JointForceCmd>(control.joint);
+        if (jfcComp)
+        {
+            auto &forceCmd = jfcComp->Data();
+            forceCmd[0] = torque;
+        }
+        else
+        {
+            gzerr << "JointForceCmd component missing for joint [" << control.jointName << "]\n";
+        }
+    }
+}
+
+
+//////////////////////////////////////////////////
+
+}  // namespace systems
+}
+}  // namespace sim
+}  // namespace gz
+
+GZ_ADD_PLUGIN(
+    gz::sim::systems::MotorPlugin,
+    gz::sim::System,
+    gz::sim::systems::MotorPlugin::ISystemConfigure,
+    gz::sim::systems::MotorPlugin::ISystemPreUpdate)
+
+GZ_ADD_PLUGIN_ALIAS(
+    gz::sim::systems::MotorPlugin,
+    "MotorPlugin")


### PR DESCRIPTION
## Description

This PR introduces a gazebo plugin of an electro-mechanical model of a motor. This plugin enhances the motor control in a model.
* The electro-mechanical model of a motor has been referred from this document:- [MIT QPROP](https://web.mit.edu/drela/Public/web/qprop/motor1_theory.pdf)
* It also contains a script to publish motor variables  (rpm, current, voltage, temperature) on a DroneCAN ESC type telemetry topic. 
* The plugin has been tested on iris quadcopter. 

## Details
1. The ArduPilotPlugin in "VELOCITY" mode sends desired velocity data on a topic. The velocity data is being converted back to pwm again which will be used as an input to the MotorPlugin.  
2. The plugin then calculates the desired torque to be given to the gazebo joint. The plugin takes current velocity of the joint as a feedback for torque calculation. 
3. This addition also makes the joint back driven. In the previous implementation, the PID controller takes desired velocity as input and drives the motor to reach that velocity. This conflicts to make the joint self driven. 
4. The new implementation controls the torque using electro-mechanical motor equations based on the PWM input which comes from ArduPilot SITL and ArduPilot SITL takes feedback of Flight Dynamics to update PWM signal, making the joint self-driven when zero input is provided which was not supported in previous implementation as zero PWM would drive the joint to achieve zero velocity.
5. Their is a custom gazebo message which stores motor stats data (rpm, current, voltage and temperature) which publishes on a topic. 
6. The published topics are then subscribed by a python script which publishes the motor stats data on DroneCAN ESC type telemetry topic. This could act as a better approach for communication between ArduPilot SITL and gazebo. More details are mentioned in [Sending Gazebo sensor data to ArduPilot using DroneCAN](https://discuss.ardupilot.org/t/sending-gazebo-sensor-data-to-ardupilot-using-dronecan/125730) blog for choosing approach. 

## How to use this plugin?
Include this in the sdf file:- 
```
<plugin filename="MotorPlugin" name="MotorPlugin">
        <control channel="0">
          <joint_name>joint_0</joint_name> <!--name of the joint -->
          <voltage_bat>16.4</voltage_bat> <!-- Battery voltage in Volts -->
          <speed_constant>920</speed_constant> <!-- Motor KV rating in RPM/Volt -->
          <resistance>0.115</resistance> <!-- Winding resistance in Ohms -->
          <no_load_current>0.8</no_load_current> <!-- No-load current in Amps -->
          <cmd_topic>joint_0</cmd_topic> <!-- Output topic for motor stats -->
          <multiplier>838</multiplier> <!-- Same multiplier used in ArduPilotPlugin for same control channel -->
          <offset>0</offset> <!-- Same offset used in ArduPilotPlugin for same control channel -->
          <thermal_resistance>1.4</thermal_resistance> <!-- °C/W, estimated for a motor --> 
          <thermal_capacitance>214.28</thermal_capacitance> <!-- °C/W, estimated for a motor -->
          <ambient_temperature>25.0</ambient_temperature> <!-- Normal room temperature -->
        </control>
</plugin>
```
-  You can keep adding more channels and sub parameters based on number of motors.  
- The parameters of this example motor are taken from [AIR 2216 920KV](https://store.tmotor.com/product/air-gear-450II-combo-set.html)motor's datasheet which is being used in iris quadcopter.  
- For calculating thermal parameters:- 
   - Power loss calculation:- 
      ```
      P_loss = P_resistive + P_friction
      P_resistive = I^2 * R = 16.37^2 * 0.115
      P_friction  = i_0 * v_m   (no-load current * back-EMF)
      P_loss = 39.38 W   (at full throttle)
      ```
   - Thermal resistance
     ```
     R_th = (T - T_amb) / P_loss
     = (80 - 25) / 39.38
     = 1.40 °C/W
     (T = temperature at full throttle, given in datasheet)
     ```
   - Thermal capacitance
     ```
     C_th = τ / R_th
          = 300 / 1.40
          = 214.28 J/°C
     (τ = thermal time constant, estimated from datasheet)
     ```
- This PR already has this plugin included in iris_with_gimbal model. When you run that using
   - Terminal 1: ```gz sim -v4 -r iris_runway.sdf```
   - Terminal 2: ```sim_vehicle.py -v ArduCopter -f gazebo-iris --model JSON --console --map```

- You will see the ../../motor_stats topics being published for 4 different copter joints.  
- To see the logs of the topics, go to build directory in ardupilot_gazebo/ workspace and run:
   ```export GZ_DESCRIPTOR_PATH=`pwd``` 
- This will set the [GZ_DESCRIPTOR_PATH](https://gazebosim.org/api/msgs/10/classgz_1_1msgs_1_1MessageFactory.html) and you'll be able to see the output in terminal. 
- To run the python script which subscribes to these motor stats topic and publishes DroneCAN ESC type telemetry data. First run this: 
  - ```export PYTHONPATH=$PYTHONPATH:`pwd`/build/ardupilot_gazebo-msgs_genmsg/python/``` in ardupilot_gazebo/ workspace.
  - ```python3 scripts/motor_stats.py``` from the same ardupilot_gazebo/ workspace. 

## Future works
- The current model only supports BLDC motors. The model based approach can be extended for servo motors as well which are used by models like gimbals. 
- The repository currently doesn't holds a proper model which converts pwm signal to desired velocity accurately as per motor's datasheet. This will eventually get removed when servo motor model is done. Then direct PWM signal can be sent on topics. 
- As mentioned in the blog post mentioned above the communicating layer between ArduPilot SITL and gazebo can be enhanced by DroneCAN messages type data transfer. 
