### PR TITLE
fix: fix multi-drone IP corruption and offline recovery deadlock

### DIFF
--- a/include/SocketUDP.hh
+++ b/include/SocketUDP.hh
@@ -61,11 +61,7 @@ public:
     /// \brief Receive data.
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
-    /// \brief Get last client address and port (raw pointer, shared static buffer)
-    [[deprecated("use get_client_address_str; raw variant returns pointer into shared static buffer")]]
-    void get_client_address(const char *&ip_addr, uint16_t &port);
-
-    /// \brief Get last client address and port (copies address into std::string)
+    /// \brief Get last client address and port as std::string.
     void get_client_address_str(std::string &ip_addr, uint16_t &port);
 
 private:

--- a/include/SocketUDP.hh
+++ b/include/SocketUDP.hh
@@ -20,6 +20,7 @@
 
 #include <fcntl.h>
 #include <unistd.h>
+#include <string>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -60,8 +61,11 @@ public:
     /// \brief Receive data.
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
-    /// \brief Get last client address and port
+    /// \brief Get last client address and port (raw pointer, shared static buffer)
     void get_client_address(const char *&ip_addr, uint16_t &port);
+
+    /// \brief Get last client address and port (copies address into std::string)
+    void get_client_address_str(std::string &ip_addr, uint16_t &port);
 
 private:
     /// \brief File descriptor.

--- a/include/SocketUDP.hh
+++ b/include/SocketUDP.hh
@@ -62,6 +62,7 @@ public:
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
     /// \brief Get last client address and port (raw pointer, shared static buffer)
+    [[deprecated("use get_client_address_str; raw variant returns pointer into shared static buffer")]]
     void get_client_address(const char *&ip_addr, uint16_t &port);
 
     /// \brief Get last client address and port (copies address into std::string)

--- a/src/ArduPilotPlugin.cc
+++ b/src/ArduPilotPlugin.cc
@@ -230,7 +230,7 @@ class gz::sim::systems::ArduPilotPluginPrivate
   public: std::string fdm_address{"127.0.0.1"};
 
   /// \brief The address for the SITL flight controller - auto detected
-  public: const char* fcu_address{nullptr};
+  public: std::string fcu_address;
 
   /// \brief The port for the flight dynamics model
   public: uint16_t fdm_port_in{9002};
@@ -1422,7 +1422,7 @@ namespace
 template<typename TServoPacket>
 ssize_t getServoPacket(
   SocketUDP &_sock,
-  const char *&_fcu_address,
+  std::string &_fcu_address,
   uint16_t &_fcu_port_out,
   uint32_t _waitMs,
   const std::string &_modelName,
@@ -1431,7 +1431,7 @@ ssize_t getServoPacket(
 {
     ssize_t recvSize = _sock.recv(&_pkt, sizeof(TServoPacket), _waitMs);
 
-    _sock.get_client_address(_fcu_address, _fcu_port_out);
+    _sock.get_client_address_str(_fcu_address, _fcu_port_out);
 
     // drain the socket in the case we're backed up
     int counter = 0;
@@ -1599,8 +1599,9 @@ bool gz::sim::systems::ArduPilotPlugin::ReceiveServoPacket()
         gzwarn << "ArduPilot controller has reset\n";
     }
 
-    // check for duplicate frame
-    else if (pkt_frame_count == this->dataPtr->fcu_frame_count)
+    // check for duplicate frame (only when online; offline allows recovery)
+    else if (pkt_frame_count == this->dataPtr->fcu_frame_count
+             && this->dataPtr->arduPilotOnline)
     {
         gzwarn << "Duplicate input frame\n";
 
@@ -2031,7 +2032,7 @@ void gz::sim::systems::ArduPilotPlugin::SendState() const
     this->dataPtr->sock.sendto(
         this->dataPtr->json_str.c_str(),
         this->dataPtr->json_str.size(),
-        this->dataPtr->fcu_address,
+        this->dataPtr->fcu_address.c_str(),
         this->dataPtr->fcu_port_out);
 
 #if DEBUG_JSON_IO

--- a/src/SocketUDP.cc
+++ b/src/SocketUDP.cc
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 
 SocketUDP::SocketUDP(bool reuseaddress, bool blocking) {
@@ -114,13 +115,10 @@ ssize_t SocketUDP::recv(void *buf, size_t size, uint32_t timeout_ms) {
 }
 
 
-void SocketUDP::get_client_address(const char *&ip_addr, uint16_t &port) {
-    ip_addr = inet_ntoa(in_addr.sin_addr);
-    port = ntohs(in_addr.sin_port);
-}
-
 void SocketUDP::get_client_address_str(std::string &ip_addr, uint16_t &port) {
-    ip_addr = inet_ntoa(in_addr.sin_addr);
+    char buffer[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &in_addr.sin_addr, buffer, INET_ADDRSTRLEN);
+    ip_addr = buffer;
     port = ntohs(in_addr.sin_port);
 }
 

--- a/src/SocketUDP.cc
+++ b/src/SocketUDP.cc
@@ -119,6 +119,11 @@ void SocketUDP::get_client_address(const char *&ip_addr, uint16_t &port) {
     port = ntohs(in_addr.sin_port);
 }
 
+void SocketUDP::get_client_address_str(std::string &ip_addr, uint16_t &port) {
+    ip_addr = inet_ntoa(in_addr.sin_addr);
+    port = ntohs(in_addr.sin_port);
+}
+
 
 bool SocketUDP::pollin(uint32_t timeout_ms) {
     fd_set fds;


### PR DESCRIPTION
## Problem

When running multiple drones simultaneously with Gazebo on the host and each drone's ArduPilot SITL inside a separate Docker container, one drone would consistently fail to receive JSON state updates from the ArduPilot plugin, showing `Broken ArduPilot connection` and `no link` in MAVProxy.

**Setup:**
- Gazebo (host) with 2 x `ArduPilotPlugin` instances (`iris_1`, `iris_2`)
- `drone-1` container: SITL communicating via Docker bridge (`172.18.0.x → 172.18.0.1`)
- `drone-2` container: SITL communicating via Docker bridge

## Root Cause

Two bugs:

**1. `inet_ntoa` static buffer overwrite**
`fcu_address` was stored as `const char*` pointing to `inet_ntoa`'s static thread-local buffer. Since both plugin instances run sequentially in the same thread, `iris_2`'s `get_client_address` call overwrites the buffer before `iris_1`'s `PostUpdate` sends state — causing `iris_1` to send JSON to `iris_2`'s IP address instead.

**2. Offline recovery deadlock**
Once `arduPilotOnline=false` (after timeout), the SITL resends the last servo packet with the same `frame_count`. The duplicate frame check would return `false` before reaching the `arduPilotOnline=true` recovery path, making recovery impossible without a full restart.

## Fix

- Store `fcu_address` as `std::string` (copied value) via a new `get_client_address_str()` method, so each plugin instance holds its own IP string
- Skip the duplicate frame check when `arduPilotOnline=false` to allow the recovery path to execute

## Test plan

- [ ] Single drone: verify connection stable as before
- [ ] Two drones simultaneously (host Gazebo + Docker SITLs): verify both maintain stable MAVLink link without `Broken ArduPilot connection` or IP mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)