### PR TITLE
CameraZoomPlugin: support all camera-family sensor components

### DIFF
--- a/src/CameraZoomPlugin.cc
+++ b/src/CameraZoomPlugin.cc
@@ -39,7 +39,13 @@
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
 
+#include <gz/sim/components/BoundingBoxCamera.hh>
 #include <gz/sim/components/Camera.hh>
+#include <gz/sim/components/DepthCamera.hh>
+#include <gz/sim/components/RgbdCamera.hh>
+#include <gz/sim/components/SegmentationCamera.hh>
+#include <gz/sim/components/ThermalCamera.hh>
+#include <gz/sim/components/WideAngleCamera.hh>
 #include <gz/sim/components/Model.hh>
 #include <gz/sim/components/Name.hh>
 #include <gz/sim/components/ParentEntity.hh>
@@ -103,6 +109,16 @@ class CameraZoomPlugin::Impl
 
     return std::optional<sim::Entity>(parent->Data());
   }
+
+  /// \todo(srmainwaring) replace with `gz::sim::Sensor` when available.
+  /// \brief Get the sdf::Sensor from any camera-family component on the entity.
+  /// LogicalCamera is excluded (no sdf::Camera, no zoom semantics).
+  /// \param[out] _typeId Matched component type id, or kComponentTypeIdInvalid.
+  /// \return sdf::Sensor* on success, nullptr if no supported component.
+  public: sdf::Sensor *CameraSensorSdf(
+    EntityComponentManager &_ecm,
+    Entity _entity,
+    ComponentTypeId &_typeId) const;
 
   /// \brief World occupied by the parent model.
   public: World world{kNullEntity};
@@ -237,6 +253,51 @@ void CameraZoomPlugin::Impl::InitialiseCamera()
       return;
     }
   }
+}
+
+//////////////////////////////////////////////////
+sdf::Sensor *CameraZoomPlugin::Impl::CameraSensorSdf(
+    EntityComponentManager &_ecm,
+    Entity _entity,
+    ComponentTypeId &_typeId) const
+{
+  _typeId = kComponentTypeIdInvalid;
+  if (auto *c = _ecm.Component<components::Camera>(_entity))
+  {
+    _typeId = components::Camera::typeId;
+    return &c->Data();
+  }
+  if (auto *c = _ecm.Component<components::BoundingBoxCamera>(_entity))
+  {
+    _typeId = components::BoundingBoxCamera::typeId;
+    return &c->Data();
+  }
+  if (auto *c = _ecm.Component<components::DepthCamera>(_entity))
+  {
+    _typeId = components::DepthCamera::typeId;
+    return &c->Data();
+  }
+  if (auto *c = _ecm.Component<components::RgbdCamera>(_entity))
+  {
+    _typeId = components::RgbdCamera::typeId;
+    return &c->Data();
+  }
+  if (auto *c = _ecm.Component<components::SegmentationCamera>(_entity))
+  {
+    _typeId = components::SegmentationCamera::typeId;
+    return &c->Data();
+  }
+  if (auto *c = _ecm.Component<components::ThermalCamera>(_entity))
+  {
+    _typeId = components::ThermalCamera::typeId;
+    return &c->Data();
+  }
+  if (auto *c = _ecm.Component<components::WideAngleCamera>(_entity))
+  {
+    _typeId = components::WideAngleCamera::typeId;
+    return &c->Data();
+  }
+  return nullptr;
 }
 
 //////////////////////////////////////////////////
@@ -409,8 +470,10 @@ void CameraZoomPlugin::PreUpdate(
   /// \todo(srmainwaring) replace with `gz::sim::Sensor` when available.
   // Entity cameraEntity = this->impl->cameraSensor.Entity();
   Entity cameraEntity = this->impl->cameraSensorEntity;
-  auto comp = _ecm.Component<components::Camera>(cameraEntity);
-  if (!comp)
+  ComponentTypeId sensorTypeId = kComponentTypeIdInvalid;
+  sdf::Sensor *sensorSdf =
+      this->impl->CameraSensorSdf(_ecm, cameraEntity, sensorTypeId);
+  if (!sensorSdf)
     return;
 
   if (this->impl->zoomChanged)
@@ -430,8 +493,7 @@ void CameraZoomPlugin::PreUpdate(
   }
 
   // Update component.
-  sdf::Sensor &sensor = comp->Data();
-  sdf::Camera *cameraSdf = sensor.CameraSensor();
+  sdf::Camera *cameraSdf = sensorSdf->CameraSensor();
   if (!cameraSdf)
     return;
 
@@ -478,7 +540,7 @@ void CameraZoomPlugin::PreUpdate(
       sensorWidth, newFocalLength);
   // Update rendering camera with the latest focal length.
   cameraSdf->SetHorizontalFov(newHfov);
-  _ecm.SetChanged(cameraEntity, components::Camera::typeId,
+  _ecm.SetChanged(cameraEntity, sensorTypeId,
     ComponentState::OneTimeChange);
 
   // Update rendering camera.

--- a/tests/worlds/test_camera_zoom_boundingbox.sdf
+++ b/tests/worlds/test_camera_zoom_boundingbox.sdf
@@ -1,0 +1,110 @@
+<?xml version="1.0" ?>
+<sdf version="1.9">
+  <world name="test_camera_zoom_boundingbox">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
+    <plugin name="gz::sim::systems::Physics"
+      filename="gz-sim-physics-system">
+    </plugin>
+    <plugin name="gz::sim::systems::Sensors"
+      filename="gz-sim-sensors-system">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin name="gz::sim::systems::UserCommands"
+      filename="gz-sim-user-commands-system">
+    </plugin>
+    <plugin name="gz::sim::systems::SceneBroadcaster"
+      filename="gz-sim-scene-broadcaster-system">
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>50 50</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <!-- Target box for the bounding-box camera to detect. -->
+    <model name="target">
+      <static>true</static>
+      <pose>5 0 0.5 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box><size>1 1 1</size></box>
+          </geometry>
+          <material>
+            <ambient>1 0.2 0.2 1</ambient>
+            <diffuse>1 0.2 0.2 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <!-- Sensor mount carrying a boundingbox_camera with CameraZoomPlugin.
+         Regression fixture for ArduPilot/ardupilot_gazebo issue #129:
+         CameraZoomPlugin must drive HFOV for non-Camera sensor components
+         (BoundingBoxCamera here, plus DepthCamera, RgbdCamera,
+         SegmentationCamera, ThermalCamera, WideAngleCamera).
+         To exercise: launch this world and publish on the zoom topic, e.g.
+           gz topic -t /model/cam_mount/sensor/camera/zoom/cmd_zoom \
+             -m gz.msgs.Double -p 'data: 4.0'
+         Before the fix, HFOV stays at 2.0 rad. After the fix it converges to
+         refHfov / zoom = 0.5 rad. -->
+    <model name="cam_mount">
+      <static>true</static>
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="link">
+        <sensor name="camera" type="boundingbox_camera">
+          <topic>boxes</topic>
+          <pose>0 0 0 0 0 0</pose>
+          <camera>
+            <box_type>2d</box_type>
+            <horizontal_fov>2.0</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>10</update_rate>
+
+          <plugin filename="CameraZoomPlugin" name="CameraZoomPlugin">
+            <max_zoom>125.0</max_zoom>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
Fixes #129.

## Problem

`CameraZoomPlugin::PreUpdate` looked up only `components::Camera` on the sensor entity, so the early-return fired for every other camera-family variant: `boundingbox_camera`, `depth_camera`, `rgbd_camera`, `segmentation`, `thermal`, `wideanglecamera`.

## Fix

Added `Impl::CameraSensorSdf` helper that fans out across the camera-family components and returns the matched `ComponentTypeId`. `PreUpdate` uses it for both lookup and `_ecm.SetChanged(...)`. `LogicalCamera` is excluded (no `sdf::Camera`).

## Verification

Built against `gz-sim 8.11.0` (Ubuntu 24.04). For each of 7 sensor types: minimal world + `gz.msgs.Double{ data: 4.0 }` on `/model/cam_mount/sensor/camera/zoom/cmd_zoom`. Pre-fix: only `camera` converged to `refHfov / zoom = 0.5 rad`; others stayed at 2.0 rad. Post-fix: all 7 converge.

## Test fixture

Adds `tests/worlds/test_camera_zoom_boundingbox.sdf` as in-tree reproducer for the bbox case.
