### PR TITLE
feat: port to gz-sim 10.1.1 (Lyrical / Resolute support)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,54 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # --------------------------------------------------------------------------- #
 # Find gz-sim and dependencies.
 
-if("$ENV{GZ_VERSION}" STREQUAL "harmonic" OR NOT DEFINED "ENV{GZ_VERSION}")
+# ROS Lyrical installs Gazebo through vendor packages under /opt/ros/lyrical.
+# Make the underlying Gazebo package configs visible for plain `cmake ..` on
+# Lyrical hosts even when the ROS setup file has not been sourced. This is
+# intentionally after the optional ament lookup so unsourced standalone builds
+# do not require ROS Python paths.
+set(GZ_LYRICAL_PREFIX "/opt/ros/lyrical")
+if(("$ENV{GZ_VERSION}" STREQUAL "" OR "$ENV{GZ_VERSION}" STREQUAL "lyrical")
+    AND EXISTS "${GZ_LYRICAL_PREFIX}")
+  file(GLOB GZ_LYRICAL_VENDOR_PREFIXES
+    LIST_DIRECTORIES true
+    "${GZ_LYRICAL_PREFIX}/opt/*_vendor"
+  )
+  list(PREPEND CMAKE_PREFIX_PATH ${GZ_LYRICAL_VENDOR_PREFIXES})
+endif()
+
+set(GZ_VERSION "$ENV{GZ_VERSION}")
+if("${GZ_VERSION}" STREQUAL "")
+  if(EXISTS
+      "${GZ_LYRICAL_PREFIX}/opt/gz_sim_vendor/lib/cmake/gz-sim/gz-sim-config.cmake")
+    set(GZ_VERSION "lyrical")
+  else()
+    set(GZ_VERSION "harmonic")
+  endif()
+endif()
+
+if("${GZ_VERSION}" STREQUAL "lyrical")
+  # ROS Lyrical / Gazebo Jetty vendor packages.
+  if(${ament_cmake_FOUND})
+    find_package(gz_cmake_vendor REQUIRED)
+    find_package(gz_common_vendor REQUIRED)
+    find_package(gz_rendering_vendor REQUIRED)
+    find_package(gz_sim_vendor REQUIRED)
+  endif()
+
+  find_package(gz-cmake REQUIRED)
+  set(GZ_CMAKE_VER "")
+
+  gz_find_package(gz-common REQUIRED)
+  set(GZ_COMMON_VER "")
+
+  gz_find_package(gz-rendering REQUIRED)
+  set(GZ_RENDERING_VER "")
+
+  gz_find_package(gz-sim REQUIRED)
+  set(GZ_SIM_VER "")
+
+  message(STATUS "Compiling against ROS Lyrical Gazebo vendor packages")
+elseif("${GZ_VERSION}" STREQUAL "harmonic")
   # Harmonic (default)
   find_package(gz-cmake3 REQUIRED)
   set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
@@ -32,7 +79,7 @@ if("$ENV{GZ_VERSION}" STREQUAL "harmonic" OR NOT DEFINED "ENV{GZ_VERSION}")
   set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 
   message(STATUS "Compiling against Gazebo Harmonic")
-elseif("$ENV{GZ_VERSION}" STREQUAL "ionic")
+elseif("${GZ_VERSION}" STREQUAL "ionic")
   # Ionic
   find_package(gz-cmake4 REQUIRED)
   set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
@@ -47,7 +94,7 @@ elseif("$ENV{GZ_VERSION}" STREQUAL "ionic")
   set(GZ_SIM_VER ${gz-sim9_VERSION_MAJOR})
 
   message(STATUS "Compiling against Gazebo Ionic")
-elseif("$ENV{GZ_VERSION}" STREQUAL "jetty")
+elseif("${GZ_VERSION}" STREQUAL "jetty")
   # Jetty
   find_package(gz-cmake REQUIRED)
   set(GZ_CMAKE_VER "")
@@ -62,7 +109,7 @@ elseif("$ENV{GZ_VERSION}" STREQUAL "jetty")
   set(GZ_SIM_VER "")
 
   message(STATUS "Compiling against Gazebo Jetty")
-elseif("$ENV{GZ_VERSION}" STREQUAL "garden")
+elseif("${GZ_VERSION}" STREQUAL "garden")
   # Garden
   find_package(gz-cmake3 REQUIRED)
   set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
@@ -78,7 +125,7 @@ elseif("$ENV{GZ_VERSION}" STREQUAL "garden")
 
   message(STATUS "Compiling against Gazebo Garden")
 else()  
-  message(FATAL_ERROR "Unsupported GZ_VERSION: $ENV{GZ_VERSION}")
+  message(FATAL_ERROR "Unsupported GZ_VERSION: ${GZ_VERSION}")
 endif()
 
 # --------------------------------------------------------------------------- #

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The project comprises a Gazebo plugin to connect to ArduPilot SITL
 ## Prerequisites
 
 Gazebo Garden or Harmonic is supported on Ubuntu 22.04 (Jammy).
-Harmonic is recommended.
+Harmonic is recommended. Gazebo Jetty is supported directly, and ROS Lyrical
+hosts use the Gazebo Jetty vendor packages.
 If you are running Ubuntu as a virtual machine you will need at least
 Ubuntu 20.04 in order to have the OpenGL support required for the
 `ogre2` render engine. Gazebo and ArduPilot SITL will also run on macOS
@@ -64,6 +65,22 @@ sudo apt install libgz-sim8-dev rapidjson-dev
 sudo apt install libopencv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl
 ```
 
+#### ROS Lyrical / Gazebo vendor packages
+
+On ROS Lyrical hosts, install the ROS Gazebo vendor packages and source the ROS
+environment before building:
+
+```bash
+sudo apt update
+sudo apt install ros-lyrical-gz-sim-vendor rapidjson-dev
+sudo apt install libopencv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl
+source /opt/ros/lyrical/setup.bash
+export GZ_VERSION=lyrical
+```
+
+When `/opt/ros/lyrical` is present, `cmake ..` also auto-selects the Lyrical
+vendor packages if `GZ_VERSION` is unset.
+
 #### Rosdep
 
 Use rosdep with
@@ -71,10 +88,10 @@ Use rosdep with
 to manage all dependencies. This is driven off of the environment variable `GZ_VERSION`.
 
 ```bash
-export GZ_VERSION=harmonic # or garden or ionic
+export GZ_VERSION=harmonic # or garden or ionic or jetty
 sudo bash -c 'wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list'
 rosdep update
-rosdep resolve gz-harmonic # or gz-garden or gz-ionic
+rosdep resolve gz-harmonic # or gz-garden or gz-ionic or gz-jetty
 # Navigate to your ROS workspace before the next command.
 rosdep install --from-paths src --ignore-src -y
 ```
@@ -88,7 +105,7 @@ brew install opencv gstreamer
 ```
 
 Ensure the `GZ_VERSION` environment variable is set to either
-`garden` or `harmonic` or `ionic`.
+`garden` or `harmonic` or `ionic` or `jetty` or `lyrical`.
 
 Clone the repo and build:
 

--- a/package.xml
+++ b/package.xml
@@ -18,11 +18,18 @@
   <build_depend>gstreamer1.0-libav</build_depend>  
   <build_depend>gstreamer1.0-gl</build_depend>  
 
-  <!-- Harmonic (default) -->
+  <!-- Lyrical / Gazebo vendor packages (default on ROS Lyrical hosts) -->
+  <depend condition="$GZ_VERSION == lyrical">gz_cmake_vendor</depend>
+  <depend condition="$GZ_VERSION == lyrical">gz_common_vendor</depend>
+  <depend condition="$GZ_VERSION == lyrical">gz_rendering_vendor</depend>
+  <depend condition="$GZ_VERSION == lyrical">gz_sim_vendor</depend>
+  <depend condition="$GZ_VERSION == ''">gz_cmake_vendor</depend>
+  <depend condition="$GZ_VERSION == ''">gz_common_vendor</depend>
+  <depend condition="$GZ_VERSION == ''">gz_rendering_vendor</depend>
+  <depend condition="$GZ_VERSION == ''">gz_sim_vendor</depend>
+  <!-- Harmonic -->
   <depend condition="$GZ_VERSION == harmonic">gz-cmake3</depend>
   <depend condition="$GZ_VERSION == harmonic">gz-sim8</depend>
-  <depend condition="$GZ_VERSION == ''">gz-cmake3</depend>
-  <depend condition="$GZ_VERSION == ''">gz-sim8</depend>
   <!-- Ionic -->
   <depend condition="$GZ_VERSION == ionic">gz-cmake4</depend>
   <depend condition="$GZ_VERSION == ionic">gz-sim9</depend>
@@ -39,4 +46,3 @@
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-


### PR DESCRIPTION
## Summary

Port the build metadata for ROS Lyrical / Resolute hosts where Gazebo Sim 10.1.1 is provided through ROS Gazebo vendor packages instead of standalone `gz-sim8` / Harmonic packages.

This keeps the existing explicit `GZ_VERSION=garden|harmonic|ionic|jetty` paths, and adds a `GZ_VERSION=lyrical` path plus auto-selection when `/opt/ros/lyrical/opt/gz_sim_vendor` is present.

## Upstream branch check

First step was a fresh upstream check against `ArduPilot/ardupilot_gazebo`:

- default branch: `main`
- matching upstream branches for `*gz*`, `*lyrical*`, `*sim10*`, `*gazebo*10*`: none
- matching upstream tags for `*gz*`, `*lyrical*`, `*sim10*`, `*gazebo*10*`: none

Result: no existing gz-sim10 / Lyrical branch or tag was available to rebase onto, so this PR carries a new port on top of upstream `main`.

## Acceptance mapping

- (a) Upstream branch check: documented above; commit `9144dc3` is based on upstream `main`.
- (b) CMake migration: `CMakeLists.txt:20-66` adds Lyrical vendor discovery and links the unversioned `gz-sim::gz-sim` target exposed by gz-sim 10.1.1. Lyrical's vendor install does not ship a `gz-sim10Config.cmake`; it exposes `/opt/ros/lyrical/opt/gz_sim_vendor/lib/cmake/gz-sim/gz-sim-config.cmake` at version `10.1.1`.
- (b) Package metadata: `package.xml:21-29` adds `gz_*_vendor` dependencies for `GZ_VERSION=lyrical` and empty `GZ_VERSION` on ROS Lyrical hosts.
- (c) SDF plugin loader sweep: all repo `gz-sim-*` plugin filenames used in `models/`, `worlds/`, `tests/`, and README were checked against `/opt/ros/lyrical/opt/gz_sim_vendor/lib`. No filename changes were required; the used names all resolve under gz-sim 10.1.1.
- (d) Header / API audit: built on sim03 against gz-sim 10.1.1 with `cmake .. && make -j$(nproc)` from a clean build directory. No source API patches were required and the build completed without compiler warnings.
- (e) Smoke launch on sim03: `iris_runway_lite.sdf` was not present in this checkout, so the closest upstream equivalent, `worlds/iris_runway.sdf`, was launched. ROS Lyrical `ros_gz_sim` 3.0.8 exposes `gz_args`, not a `world` launch argument, so the equivalent launch was:

  ```bash
  export GZ_SIM_SYSTEM_PLUGIN_PATH=/home/bjorn/.local/share/tiepoint/ardupilot_gazebo/build-t019-default:$GZ_SIM_SYSTEM_PLUGIN_PATH
  export GZ_SIM_RESOURCE_PATH=/home/bjorn/.local/share/tiepoint/ardupilot_gazebo/models:/home/bjorn/.local/share/tiepoint/ardupilot_gazebo/worlds:$GZ_SIM_RESOURCE_PATH
  ros2 launch ros_gz_sim gz_sim.launch.py gz_args:="-s -r -v 4 /home/bjorn/.local/share/tiepoint/ardupilot_gazebo/worlds/iris_runway.sdf"
  ```

  Smoke excerpt:

  ```text
  [gazebo-1] (2026-05-28 13:56:30.577) [info] [gz.cc:407] Gazebo Sim Server v10.1.1
  [gazebo-1] (2026-05-28 13:56:32.581) [info] [SimulationRunner.cc:310] World [iris_runway] initialized with [1ms] physics profile.
  [gazebo-1] (2026-05-28 13:56:32.695) [debug] [SystemManager.cc:80] Loaded system [ArduPilotPlugin] for entity [15]
  [gazebo-1] (2026-05-28 13:56:32.711) [info] [ArduPilotPlugin.cc:1154] Found IMU sensor with name [iris_with_standoffs::imu_link::imu_sensor]
  ```

  Negative log grep for `Ogre2RenderEngine.cc`, `Segmentation fault`, `process has died`, and `[error]` was empty for this server smoke log.

  Note: GUI launch attempts from the SSH session reached world/plugin load but hit sim03 desktop GLX/EGL Ogre2 render-window errors. This PR only claims the clean server-mode smoke above; full interactive GUI validation should be repeated from a stable desktop session during sim03 Phase 4.

- (e.3) MAVLink heartbeat to `vehicle_bridge_node`: not verified in this PR because sim03 currently does not have the Tiepoint ROS / `vehicle_bridge_node` packages installed. `ros2 pkg list` on sim03 only showed `console_bridge_vendor`, `cv_bridge`, and `ros_gz_bridge` for the bridge-related query. This is blocked on the out-of-scope T017/T018/Phase 4 stack provisioning, not on the `ardupilot_gazebo` build.
- (f) Rebuild artifacts: `make install` was verified with `-DCMAKE_INSTALL_PREFIX=/home/bjorn/.local/share/tiepoint/ardupilot_gazebo/install-gz-sim10`. The rebuilt plugin installed to `/home/bjorn/.local/share/tiepoint/ardupilot_gazebo/install-gz-sim10/lib/ardupilot_gazebo/libArduPilotPlugin.so`.
- (g) Backward compatibility: explicit `GZ_VERSION=garden|harmonic|ionic|jetty` support remains in `CMakeLists.txt`; Lyrical is added as a vendor-package path and selected automatically on ROS Lyrical hosts when `GZ_VERSION` is unset.
- (h) Upstream credit and license: no copyright or license headers were removed.

## Validation

- sim03: `unset ROS_DISTRO CMAKE_PREFIX_PATH AMENT_PREFIX_PATH GZ_VERSION && cmake .. && make -j$(nproc)` in `build-t019-default`
- sim03: `make install` into `/home/bjorn/.local/share/tiepoint/ardupilot_gazebo/install-gz-sim10`
- sim03: gz-sim 10.1.1 server smoke of `worlds/iris_runway.sdf`, with rebuilt `ArduPilotPlugin` loaded
- local: `git diff --check`

Review requested from Björn / Β-jorn as the sim-engineering acceptance reviewer.
