### PR TITLE
GstCameraPlugin: fix queue backlog latency and nvh264enc pipeline

### DIFF
--- a/src/GstCameraPlugin.cc
+++ b/src/GstCameraPlugin.cc
@@ -410,13 +410,17 @@ void GstCameraPlugin::Impl::CreateGenericPipeline(GstElement *pipeline)
     GstElement *queue = gst_element_factory_make("queue", nullptr);
     GstElement *converter = gst_element_factory_make("videoconvert", nullptr);
     GstElement *encoder = CreateEncoder();
+    GstElement *h264_parser = gst_element_factory_make("h264parse", nullptr);
     GstElement *payloader = gst_element_factory_make("rtph264pay", nullptr);
     GstElement *sink = gst_element_factory_make("udpsink", nullptr);
 
+    g_object_set(G_OBJECT(queue), "max-size-buffers", 1,
+        "max-size-bytes", 0, "max-size-time", 0, "leaky", 2, nullptr);
     g_object_set(G_OBJECT(sink), "host", udpHost.c_str(),
         "port", udpPort, nullptr);
 
-    if (!source || !queue || !converter || !encoder || !payloader || !sink)
+    if (!source || !queue || !converter || !encoder || !h264_parser
+        || !payloader || !sink)
     {
         gzerr << "GstCameraPlugin: failed to create GStreamer elements"
               << std::endl;
@@ -425,11 +429,11 @@ void GstCameraPlugin::Impl::CreateGenericPipeline(GstElement *pipeline)
 
     // Connect all elements to pipeline
     gst_bin_add_many(GST_BIN(pipeline), source, queue, converter, encoder,
-        payloader, sink, nullptr);
+        h264_parser, payloader, sink, nullptr);
 
     // Link all elements
     if (gst_element_link_many(source, queue, converter, encoder,
-        payloader, sink, nullptr) != TRUE)
+        h264_parser, payloader, sink, nullptr) != TRUE)
     {
         gzerr << "GstCameraPlugin: failed to link GStreamer elements"
               << std::endl;
@@ -448,6 +452,10 @@ void GstCameraPlugin::Impl::CreateMpeg2tsPipeline(GstElement *pipeline)
     GstElement *queue_mpeg = gst_element_factory_make("queue", nullptr);
     GstElement *sink = gst_element_factory_make("udpsink", nullptr);
 
+    g_object_set(G_OBJECT(queue), "max-size-buffers", 1,
+        "max-size-bytes", 0, "max-size-time", 0, "leaky", 2, nullptr);
+    g_object_set(G_OBJECT(queue_mpeg), "max-size-buffers", 1,
+        "max-size-bytes", 0, "max-size-time", 0, "leaky", 2, nullptr);
     g_object_set(G_OBJECT(payloader), "alignment", 7, nullptr);
     g_object_set(G_OBJECT(sink), "host", udpHost.c_str(), "port", udpPort,
         "sync", false, nullptr);
@@ -478,7 +486,8 @@ GstElement* GstCameraPlugin::Impl::CreateEncoder()
     {
         gzdbg << "Using Cuda" << std::endl;
         encoder = gst_element_factory_make("nvh264enc", nullptr);
-        g_object_set(G_OBJECT(encoder), "bitrate", 800, "preset", 1, nullptr);
+        g_object_set(G_OBJECT(encoder), "bitrate", 800, "preset", 5,
+            "gop-size", 10, nullptr);
     }
     else
     {

--- a/src/GstCameraPlugin.cc
+++ b/src/GstCameraPlugin.cc
@@ -427,10 +427,6 @@ void GstCameraPlugin::Impl::CreateGenericPipeline(GstElement *pipeline)
         return;
     }
 
-    // Keep each IDR independently decodable for receivers joining mid-stream.
-    g_object_set(G_OBJECT(h264_parser), "config-interval", -1, nullptr);
-    g_object_set(G_OBJECT(payloader), "config-interval", -1, nullptr);
-
     // Connect all elements to pipeline
     gst_bin_add_many(GST_BIN(pipeline), source, queue, converter, encoder,
         h264_parser, payloader, sink, nullptr);
@@ -491,7 +487,7 @@ GstElement* GstCameraPlugin::Impl::CreateEncoder()
         gzdbg << "Using Cuda" << std::endl;
         encoder = gst_element_factory_make("nvh264enc", nullptr);
         g_object_set(G_OBJECT(encoder), "bitrate", 800, "preset", 5,
-            "gop-size", 10, "zerolatency", true, nullptr);
+            "gop-size", 10, nullptr);
     }
     else
     {

--- a/src/GstCameraPlugin.cc
+++ b/src/GstCameraPlugin.cc
@@ -427,6 +427,9 @@ void GstCameraPlugin::Impl::CreateGenericPipeline(GstElement *pipeline)
         return;
     }
 
+    // Repeat SPS / PPS with every IDR frame so late RTP receivers can decode.
+    g_object_set(G_OBJECT(payloader), "config-interval", -1, nullptr);
+
     // Connect all elements to pipeline
     gst_bin_add_many(GST_BIN(pipeline), source, queue, converter, encoder,
         h264_parser, payloader, sink, nullptr);

--- a/src/GstCameraPlugin.cc
+++ b/src/GstCameraPlugin.cc
@@ -427,7 +427,8 @@ void GstCameraPlugin::Impl::CreateGenericPipeline(GstElement *pipeline)
         return;
     }
 
-    // Repeat SPS / PPS with every IDR frame so late RTP receivers can decode.
+    // Keep each IDR independently decodable for receivers joining mid-stream.
+    g_object_set(G_OBJECT(h264_parser), "config-interval", -1, nullptr);
     g_object_set(G_OBJECT(payloader), "config-interval", -1, nullptr);
 
     // Connect all elements to pipeline
@@ -490,7 +491,7 @@ GstElement* GstCameraPlugin::Impl::CreateEncoder()
         gzdbg << "Using Cuda" << std::endl;
         encoder = gst_element_factory_make("nvh264enc", nullptr);
         g_object_set(G_OBJECT(encoder), "bitrate", 800, "preset", 5,
-            "gop-size", 10, nullptr);
+            "gop-size", 10, "zerolatency", true, nullptr);
     }
     else
     {


### PR DESCRIPTION
Add leaky queue limits to prevent frame backlog buildup in all pipelines. Without limits the default 200-frame queue causes hundreds of ms of latency when the encoder cannot keep pace with the camera frame rate.

Add h264parse between nvh264enc and rtph264pay in the generic pipeline to fix caps negotiation that caused the CUDA path to fail silently.

Update nvh264enc to use low-latency-hp preset and set gop-size to match the key-int-max used by the x264enc path.

Tested on Ubuntu 22.04, Gazebo Harmonic, NVIDIA RTX 3050 (driver 550, GStreamer 1.20.3). Both CPU (x264enc) and CUDA (nvh264enc) paths build and run without errors.